### PR TITLE
Replace type assertion with built-in error detection

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -53,10 +53,8 @@ class OpenAi {
     } catch (error: unknown) {
       outro(`${chalk.red('✖')} ${error}`);
 
-      if (axios.isAxiosError(error) && error.response?.status === 401) {
-        const openAiError = (
-          error.response?.data as { error?: { message: string } }
-        ).error;
+      if (axios.isAxiosError<{ error?: { message: string } }>(error) && error.response?.status === 401) {
+        const openAiError = error.response?.data.error;
 
         if (openAiError?.message) outro(openAiError.message);
         outro(

--- a/src/api.ts
+++ b/src/api.ts
@@ -54,7 +54,7 @@ class OpenAi {
       outro(`${chalk.red('✖')} ${error}`);
 
       if (axios.isAxiosError<{ error?: { message: string } }>(error) && error.response?.status === 401) {
-        const openAiError = error.response?.data.error;
+        const openAiError = error.response.data.error;
 
         if (openAiError?.message) outro(openAiError.message);
         outro(

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,5 @@
 import { intro, outro } from '@clack/prompts';
-import { AxiosError } from 'axios';
+import axios from 'axios';
 import chalk from 'chalk';
 import {
   ChatCompletionRequestMessage,
@@ -50,14 +50,12 @@ class OpenAi {
       const message = data.choices[0].message;
 
       return message?.content;
-    } catch (error: any) {
+    } catch (error: unknown) {
       outro(`${chalk.red('✖')} ${error}`);
 
-      if (error.isAxiosError && error.response?.status === 401) {
-        const err = error as AxiosError;
-
+      if (axios.isAxiosError(error) && error.response?.status === 401) {
         const openAiError = (
-          err.response?.data as { error?: { message: string } }
+          error.response?.data as { error?: { message: string } }
         ).error;
 
         if (openAiError?.message) outro(openAiError.message);


### PR DESCRIPTION
Axios provides a util function called `isAxiosError` which can detect the shape of your error. By using it, we can avoid the [type assertion](https://typescript.tv/glossary/#Type-Assertion) of `error as AxiosError`. 

The error handling code will be now more type-safe since we no longer have to use the `any` type for the error variable (see [better error handling with unknown type](https://www.youtube.com/watch?v=xdQkEn3mx1k)).