### PR TITLE
feat: Add support for extra args to be passed to the git commit command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ All the commits in this repo are done with OpenCommit — look into [the commits
 
 ## Setup
 
-> The minimum supported version of Node.js is the latest v14. Check your Node.js version with `node --version`.
-
 1. Install opencommit globally to use in any repository:
 
    ```sh
@@ -86,6 +84,20 @@ To remove description:
 oc config set description=false
 ```
 
+### Git flags
+
+The `opencommit` or `oc` commands can be used in place of the `git commit -m "${generatedMessage}"` command. This means that any regular flags that are used with the `git commit` command will also be applied when using `opencommit` or `oc`.
+
+```sh
+oc --no-verify
+```
+
+is translated to :
+
+```sh
+git commit -m "${generatedMessage}" --no-verify
+```
+
 ## Git hook
 
 You can set opencommit as Git [`prepare-commit-msg`](https://git-scm.com/docs/githooks#_prepare_commit_msg) hook. Hook integrates with you IDE Source Control and allows you edit the message before commit.
@@ -113,4 +125,4 @@ Or follow the process of your IDE Source Control feature, when it calls `git com
 
 ## Payments
 
-You pay for your own requests to OpenAI API. OpenCommit uses ChatGPT official model, that is ~10x times cheaper than GPT-3.
+You pay for your own requests to OpenAI API. OpenCommit uses ChatGPT official model, that is ~10x times cheaper than GPT-3 and ~6x times cheaper than GPT-4.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,7 @@ import { hookCommand, isHookCalled } from './commands/githook.js';
 import { prepareCommitMessageHook } from './commands/prepare-commit-msg-hook';
 import { commit } from './commands/commit';
 
-const rawArgv = process.argv.slice(2);
+const extraArgs = process.argv.slice(2);
 
 cli(
   {
@@ -23,8 +23,8 @@ cli(
     if (isHookCalled) {
       prepareCommitMessageHook();
     } else {
-      commit();
+      commit(extraArgs);
     }
   },
-  rawArgv
+  extraArgs
 );

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -8,7 +8,8 @@ import { spinner, confirm, outro, isCancel, intro } from '@clack/prompts';
 import chalk from 'chalk';
 
 const generateCommitMessageFromGitDiff = async (
-  diff: string
+  diff: string,
+  extraArgs: string[]
 ): Promise<void> => {
   await assertGitRepo();
 
@@ -45,7 +46,7 @@ ${chalk.grey('——————————————————')}`
   });
 
   if (isCommitConfirmedByUser && !isCancel(isCommitConfirmedByUser)) {
-    const { stdout } = await execa('git', ['commit', '-m', commitMessage]);
+    const { stdout } = await execa('git', ['commit', '-m', commitMessage, ...extraArgs]);
     outro(`${chalk.green('✔')} successfully committed`);
     outro(stdout);
     const isPushConfirmedByUser = await confirm({
@@ -64,7 +65,7 @@ ${chalk.grey('——————————————————')}`
   } else outro(`${chalk.gray('✖')} process cancelled`);
 };
 
-export async function commit(isStageAllFlag = false) {
+export async function commit(extraArgs=[], isStageAllFlag = false) {
   intro('open-commit');
 
   const stagedFilesSpinner = spinner();
@@ -103,7 +104,7 @@ export async function commit(isStageAllFlag = false) {
       isStageAllAndCommitConfirmedByUser &&
       !isCancel(isStageAllAndCommitConfirmedByUser)
     ) {
-      await commit(true);
+      await commit(extraArgs, true);
     }
 
     process.exit(1);
@@ -115,5 +116,5 @@ export async function commit(isStageAllFlag = false) {
       .join('\n')}`
   );
 
-  await generateCommitMessageFromGitDiff(staged.diff);
+  await generateCommitMessageFromGitDiff(staged.diff, extraArgs);
 }


### PR DESCRIPTION
As the name of the PR explains I added a few lines to support some extra arguments to be passed to the `git commit` command.

For example, say I want to execute git commit with `--no-verify` using oc I simply cannot do it,

What I added makes you able to do `oc --no-verify` and it  translates to `git commit -m ${generatedText} --no-verify`