### PR TITLE
feat(config.ts): allow using env and .env to setup opencommit

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ All the commits in this repo are done with OpenCommit — look into [the commits
 3. Set the key to opencommit config:
 
    ```sh
-   opencommit config set OPENAI_API_KEY=<your_api_key>
+   opencommit config set OPENCOMMIT_OPENAI_API_KEY=<your_api_key>
    ```
 
    Your api key is stored locally in `~/.opencommit` config file.

--- a/src/api.ts
+++ b/src/api.ts
@@ -11,7 +11,7 @@ import { CONFIG_MODES, getConfig } from './commands/config';
 
 const config = getConfig();
 
-let apiKey = config?.OPENAI_API_KEY;
+let apiKey = config?.OPENCOMMIT_OPENAI_API_KEY;
 
 const [command, mode] = process.argv.slice(2);
 
@@ -19,7 +19,7 @@ if (!apiKey && command !== 'config' && mode !== CONFIG_MODES.set) {
   intro('opencommit');
 
   outro(
-    'OPENAI_API_KEY is not set, please run `oc config set OPENAI_API_KEY=<your token>. Make sure you add payment details, so API works.`'
+    'OPENCOMMIT_OPENAI_API_KEY is not set, please run `oc config set OPENCOMMIT_OPENAI_API_KEY=<your token>. Make sure you add payment details, so API works.`'
   );
   outro(
     'For help look into README https://github.com/di-sukharev/opencommit#setup'

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -48,7 +48,7 @@ export const configValidators = {
     return value;
   },
   [CONFIG_KEYS.OPENCOMMIT_DESCRIPTION](value: any) {
-    const parsedValue = typeof value === 'boolean' || value === 'true' ? value : 'false'
+    const parsedValue = typeof value === 'boolean' ? value : value === 'true' ? true : false
     validateConfig(
       CONFIG_KEYS.OPENCOMMIT_DESCRIPTION,
       typeof parsedValue === 'boolean',
@@ -58,7 +58,7 @@ export const configValidators = {
     return parsedValue;
   },
   [CONFIG_KEYS.OPENCOMMIT_EMOJI](value: any) {
-    const parsedValue = typeof value === 'boolean' || value === 'true' ? value : 'false'
+    const parsedValue = typeof value === 'boolean' ? value : value === 'true' ? true : false
     validateConfig(
       CONFIG_KEYS.OPENCOMMIT_EMOJI,
       typeof parsedValue === 'boolean',

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -9,8 +9,8 @@ import { COMMANDS } from '../CommandsEnum';
 
 export enum CONFIG_KEYS {
   OPENAI_API_KEY = 'OPENAI_API_KEY',
-  description = 'description',
-  emoji = 'emoji'
+  OPENCOMMIT_DESCRIPTION = 'OPENCOMMIT_DESCRIPTION',
+  OPENCOMMIT_EMOJI = 'OPENCOMMIT_EMOJI'
 }
 
 export enum CONFIG_MODES {
@@ -47,23 +47,25 @@ export const configValidators = {
 
     return value;
   },
-  [CONFIG_KEYS.description](value: any) {
+  [CONFIG_KEYS.OPENCOMMIT_DESCRIPTION](value: any) {
+    const parsedValue = typeof value === 'boolean' || value === 'true' ? value : 'false'
     validateConfig(
-      CONFIG_KEYS.description,
-      typeof value === 'boolean',
+      CONFIG_KEYS.OPENCOMMIT_DESCRIPTION,
+      typeof parsedValue === 'boolean',
       'Must be true or false'
     );
 
-    return value;
+    return parsedValue;
   },
-  [CONFIG_KEYS.emoji](value: any) {
+  [CONFIG_KEYS.OPENCOMMIT_EMOJI](value: any) {
+    const parsedValue = typeof value === 'boolean' || value === 'true' ? value : 'false'
     validateConfig(
-      CONFIG_KEYS.emoji,
-      typeof value === 'boolean',
+      CONFIG_KEYS.OPENCOMMIT_EMOJI,
+      typeof parsedValue === 'boolean',
       'Must be true or false'
     );
 
-    return value;
+    return parsedValue;
   }
 };
 
@@ -75,14 +77,13 @@ const configPath = pathJoin(homedir(), '.opencommit');
 
 export const getConfig = (): ConfigType | null => {
   const configExists = existsSync(configPath);
-  if (!configExists) return null;
 
-  const configFile = readFileSync(configPath, 'utf8');
-  const config = iniParse(configFile);
+  const configFile = configExists ? readFileSync(configPath, 'utf8') : '';
+  const config = configFile? iniParse(configFile) : {};
 
-  for (const configKey of Object.keys(config)) {
+  for (const configKey in CONFIG_KEYS) {
     const validValue = configValidators[configKey as CONFIG_KEYS](
-      config[configKey]
+      config.hasOwnProperty(configKey) ? config[configKey] : process.env[configKey]
     );
 
     config[configKey] = validValue;

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -7,8 +7,11 @@ import { intro, outro } from '@clack/prompts';
 import chalk from 'chalk';
 import { COMMANDS } from '../CommandsEnum';
 
+import * as dotenv from 'dotenv'
+dotenv.config()
+
 export enum CONFIG_KEYS {
-  OPENAI_API_KEY = 'OPENAI_API_KEY',
+  OPENCOMMIT_OPENAI_API_KEY = 'OPENCOMMIT_OPENAI_API_KEY',
   OPENCOMMIT_DESCRIPTION = 'OPENCOMMIT_DESCRIPTION',
   OPENCOMMIT_EMOJI = 'OPENCOMMIT_EMOJI'
 }
@@ -32,15 +35,15 @@ const validateConfig = (
 };
 
 export const configValidators = {
-  [CONFIG_KEYS.OPENAI_API_KEY](value: any) {
-    validateConfig(CONFIG_KEYS.OPENAI_API_KEY, value, 'Cannot be empty');
+  [CONFIG_KEYS.OPENCOMMIT_OPENAI_API_KEY](value: any) {
+    validateConfig(CONFIG_KEYS.OPENCOMMIT_OPENAI_API_KEY, value, 'Cannot be empty');
     validateConfig(
-      CONFIG_KEYS.OPENAI_API_KEY,
+      CONFIG_KEYS.OPENCOMMIT_OPENAI_API_KEY,
       value.startsWith('sk-'),
       'Must start with "sk-"'
     );
     validateConfig(
-      CONFIG_KEYS.OPENAI_API_KEY,
+      CONFIG_KEYS.OPENCOMMIT_OPENAI_API_KEY,
       value.length === 51,
       'Must be 51 characters long'
     );

--- a/src/commands/prepare-commit-msg-hook.ts
+++ b/src/commands/prepare-commit-msg-hook.ts
@@ -25,7 +25,7 @@ export const prepareCommitMessageHook = async () => {
 
     const config = getConfig();
 
-    if (!config?.OPENAI_API_KEY) {
+    if (!config?.OPENCOMMIT_OPENAI_API_KEY) {
       throw new Error(
         'No OPEN_AI_API exists. Set your OPEN_AI_API=<key> in ~/.opencommit'
       );

--- a/src/generateCommitMessageFromGitDiff.ts
+++ b/src/generateCommitMessageFromGitDiff.ts
@@ -3,7 +3,7 @@ import {
   ChatCompletionRequestMessageRoleEnum
 } from 'openai';
 import { api } from './api';
-import { CONFIG_KEYS, getConfig } from './commands/config';
+import { getConfig } from './commands/config';
 import { mergeStrings } from './utils/mergeStrings';
 
 const config = getConfig();
@@ -12,11 +12,11 @@ const INIT_MESSAGES_PROMPT: Array<ChatCompletionRequestMessage> = [
   {
     role: ChatCompletionRequestMessageRoleEnum.System,
     content: `You are to act as the author of a commit message in git. Your mission is to create clean and comprehensive commit messages in the conventional commit convention. I'll send you an output of 'git diff --staged' command, and you convert it into a commit message. ${
-      config?.[CONFIG_KEYS.OPENCOMMIT_EMOJI]
+      config?.OPENCOMMIT_EMOJI
         ? 'Use Gitmoji convention to preface the commit'
         : 'Do not preface the commit with anything'
     }, use the present tense. ${
-      config?.[CONFIG_KEYS.OPENCOMMIT_DESCRIPTION]
+      config?.OPENCOMMIT_DESCRIPTION
         ? 'Add a short description of what commit is about after the commit message. Don\'t start it with "This commit", just describe the changes.'
         : "Don't add any descriptions to the commit, only commit message."
     }`
@@ -49,9 +49,9 @@ const INIT_MESSAGES_PROMPT: Array<ChatCompletionRequestMessage> = [
   {
     role: ChatCompletionRequestMessageRoleEnum.Assistant,
     // prettier-ignore
-    content: `${config?.[CONFIG_KEYS.OPENCOMMIT_EMOJI] ? '🐛 ' : ''}fix(server.ts): change port variable case from lowercase port to uppercase PORT
-${config?.[CONFIG_KEYS.OPENCOMMIT_EMOJI] ? '✨ ' : ''}feat(server.ts): add support for process.env.PORT environment variable
-${config?.[CONFIG_KEYS.OPENCOMMIT_DESCRIPTION] ? 'The port variable is now named PORT, which improves consistency with the naming conventions as PORT is a constant. Support for an environment variable allows the application to be more flexible as it can now run on any available port specified via the process.env.PORT environment variable.' : ''}`
+    content: `${config?.OPENCOMMIT_EMOJI ? '🐛 ' : ''}fix(server.ts): change port variable case from lowercase port to uppercase PORT
+${config?.OPENCOMMIT_EMOJI ? '✨ ' : ''}feat(server.ts): add support for process.env.PORT environment variable
+${config?.OPENCOMMIT_DESCRIPTION ? 'The port variable is now named PORT, which improves consistency with the naming conventions as PORT is a constant. Support for an environment variable allows the application to be more flexible as it can now run on any available port specified via the process.env.PORT environment variable.' : ''}`
   }
 ];
 

--- a/src/generateCommitMessageFromGitDiff.ts
+++ b/src/generateCommitMessageFromGitDiff.ts
@@ -3,7 +3,7 @@ import {
   ChatCompletionRequestMessageRoleEnum
 } from 'openai';
 import { api } from './api';
-import { getConfig } from './commands/config';
+import { CONFIG_KEYS, getConfig } from './commands/config';
 import { mergeStrings } from './utils/mergeStrings';
 
 const config = getConfig();
@@ -12,11 +12,11 @@ const INIT_MESSAGES_PROMPT: Array<ChatCompletionRequestMessage> = [
   {
     role: ChatCompletionRequestMessageRoleEnum.System,
     content: `You are to act as the author of a commit message in git. Your mission is to create clean and comprehensive commit messages in the conventional commit convention. I'll send you an output of 'git diff --staged' command, and you convert it into a commit message. ${
-      config?.emoji
+      config?.[CONFIG_KEYS.OPENCOMMIT_EMOJI]
         ? 'Use Gitmoji convention to preface the commit'
         : 'Do not preface the commit with anything'
     }, use the present tense. ${
-      config?.description
+      config?.[CONFIG_KEYS.OPENCOMMIT_DESCRIPTION]
         ? 'Add a short description of what commit is about after the commit message. Don\'t start it with "This commit", just describe the changes.'
         : "Don't add any descriptions to the commit, only commit message."
     }`
@@ -49,9 +49,9 @@ const INIT_MESSAGES_PROMPT: Array<ChatCompletionRequestMessage> = [
   {
     role: ChatCompletionRequestMessageRoleEnum.Assistant,
     // prettier-ignore
-    content: `${config?.emoji ? '🐛 ' : ''}fix(server.ts): change port variable case from lowercase port to uppercase PORT
-${config?.emoji ? '✨ ' : ''}feat(server.ts): add support for process.env.PORT environment variable
-${config?.description ? 'The port variable is now named PORT, which improves consistency with the naming conventions as PORT is a constant. Support for an environment variable allows the application to be more flexible as it can now run on any available port specified via the process.env.PORT environment variable.' : ''}`
+    content: `${config?.[CONFIG_KEYS.OPENCOMMIT_EMOJI] ? '🐛 ' : ''}fix(server.ts): change port variable case from lowercase port to uppercase PORT
+${config?.[CONFIG_KEYS.OPENCOMMIT_EMOJI] ? '✨ ' : ''}feat(server.ts): add support for process.env.PORT environment variable
+${config?.[CONFIG_KEYS.OPENCOMMIT_DESCRIPTION] ? 'The port variable is now named PORT, which improves consistency with the naming conventions as PORT is a constant. Support for an environment variable allows the application to be more flexible as it can now run on any available port specified via the process.env.PORT environment variable.' : ''}`
   }
 ];
 


### PR DESCRIPTION
As suggested on #16 
this change allows multiple config per repo and better compatibility with ephemeral workspaces.

Still, I have the feeling that this architecture could be a bit cumbersome in the long run, it made sense to me at first because there were few parameters and it suited my workflow.

If you think it could make sense I could spin up another branch that creates and searches for the `.opencommit` file in the project root directory first before checking for a global one.