### PR TITLE
fix(git.ts): add relative flag to git diff command

### DIFF
--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -30,6 +30,7 @@ export const getStagedFiles = async (): Promise<string[]> => {
     'diff',
     '--name-only',
     '--cached',
+    '--relative'
   ]);
 
   const filesList = files.split('\n');


### PR DESCRIPTION
The relative flag has been added to the git diff command in the getStagedFiles function. This flag makes the output of the command relative to the current working directory, which makes it easier to work with the file paths and enables executing opencommit from anywhere in the repository, not just from the root.