### PR TITLE
refactor(git.ts): use git rev-parse to get the root directory of the repo

### DIFF
--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -26,11 +26,17 @@ export const getOpenCommitIgnore = (): Ignore => {
 };
 
 export const getStagedFiles = async (): Promise<string[]> => {
-  const { stdout: files } = await execa('git', [
-    'diff',
-    '--name-only',
-    '--cached',
-    '--relative'
+  const { stdout: gitDir } = await execa("git", [
+      "rev-parse",
+      "--show-toplevel"
+  ]);
+
+  const { stdout: files } = await execa("git", [
+    "diff",
+    "--name-only",
+    "--cached",
+    "--relative",
+    gitDir
   ]);
 
   if (!files) return [];


### PR DESCRIPTION
Following #37 and #38 the function getStagedFiles has been refactored to use git rev-parse to get the root directory of the repository. This improves the reliability of the function as it will work regardless of the current working directory. The root directory is then passed to the git diff command to get the list of staged files. With only the --relative flag, as I have done in #37, staged diff(s) on files in a different same level directory as the current working one would not be found by the command.