### PR TITLE
Count file diff by token, not by length of string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@clack/prompts": "^0.6.1",
+        "@dqbd/tiktoken": "^1.0.2",
         "axios": "^1.3.4",
         "chalk": "^5.2.0",
         "cleye": "^1.3.2",
@@ -82,6 +83,11 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@dqbd/tiktoken": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@dqbd/tiktoken/-/tiktoken-1.0.2.tgz",
+      "integrity": "sha512-AjGTBRWsMoVmVeN55NLyupyM8TNamOUBl6tj5t/leLDVup3CFGO9tVagNL1jf3GyZLkWZSTmYVbPQ/M2LEcNzw=="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.15.18",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^0.6.1",
+    "@dqbd/tiktoken": "^1.0.2",
     "axios": "^1.3.4",
     "chalk": "^5.2.0",
     "cleye": "^1.3.2",

--- a/src/utils/mergeStrings.ts
+++ b/src/utils/mergeStrings.ts
@@ -1,8 +1,9 @@
+import { tokenCount } from './tokenCount'
 export function mergeStrings(arr: string[], maxStringLength: number): string[] {
   const mergedArr: string[] = [];
   let currentItem: string = arr[0];
   for (const item of arr.slice(1)) {
-    if (currentItem.length + item.length <= maxStringLength) {
+    if (tokenCount(currentItem + item) <= maxStringLength) {
       currentItem += item;
     } else {
       mergedArr.push(currentItem);

--- a/src/utils/tokenCount.ts
+++ b/src/utils/tokenCount.ts
@@ -1,0 +1,14 @@
+import { Tiktoken } from "@dqbd/tiktoken/lite"
+import cl100k_base from "@dqbd/tiktoken/encoders/cl100k_base.json" assert{type: "json"}
+
+export function tokenCount(content: string): number {
+    const encoding = new Tiktoken(
+        cl100k_base.bpe_ranks,
+        cl100k_base.special_tokens,
+        cl100k_base.pat_str
+    );
+    const tokens = encoding.encode(content);
+    encoding.free();
+
+    return tokens.length;
+}


### PR DESCRIPTION
Some of the non english character, one character is larger then 1 token count. For example "居", it contains 3 tokens.  We can check the [Tokenizer](https://platform.openai.com/tokenizer) from openai. 

For example, I have two files, both have 1000 chinese characters. Let say each has 2800 token, If just count from length, that only has 2000 characters, but it already have over 5500 token.

That will lead some of messages over 4096 token size, if just count the length of string. The openai will return "Error: Request failed with status code 400",

I have implemented by import [tiktoken](https://www.npmjs.com/package/@dqbd/tiktoken) to replace the counting token method to correct this situations

