### PR TITLE
fix(githook.ts): fix SYMLINK_URL for Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.6.1",
-        "@dqbd/tiktoken": "^1.0.2",
         "axios": "^1.3.4",
         "chalk": "^5.2.0",
         "cleye": "^1.3.2",
@@ -83,11 +82,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/@dqbd/tiktoken": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@dqbd/tiktoken/-/tiktoken-1.0.2.tgz",
-      "integrity": "sha512-AjGTBRWsMoVmVeN55NLyupyM8TNamOUBl6tj5t/leLDVup3CFGO9tVagNL1jf3GyZLkWZSTmYVbPQ/M2LEcNzw=="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.15.18",

--- a/src/commands/githook.ts
+++ b/src/commands/githook.ts
@@ -6,12 +6,11 @@ import { existsSync } from 'fs';
 import chalk from 'chalk';
 import { intro, outro } from '@clack/prompts';
 import { COMMANDS } from '../CommandsEnum.js';
-import { fileURLToPath } from 'url';
 
 const HOOK_NAME = 'prepare-commit-msg';
-const SYMLINK_URL = `.git/hooks/${HOOK_NAME}`;
+const SYMLINK_URL = process.platform === "win32" ? `\\.git\\hooks\\${HOOK_NAME}` : `/.git/hooks/${HOOK_NAME}`;
 
-export const isHookCalled = process.argv[1].endsWith(`/${SYMLINK_URL}`);
+export const isHookCalled = process.argv[1].endsWith(`${SYMLINK_URL}`);
 
 const isHookExists = existsSync(SYMLINK_URL);
 

--- a/src/commands/githook.ts
+++ b/src/commands/githook.ts
@@ -8,7 +8,7 @@ import { intro, outro } from '@clack/prompts';
 import { COMMANDS } from '../CommandsEnum.js';
 
 const HOOK_NAME = 'prepare-commit-msg';
-const SYMLINK_URL = process.platform === "win32" ? `\\.git\\hooks\\${HOOK_NAME}` : `/.git/hooks/${HOOK_NAME}`;
+const SYMLINK_URL = path.join(path.sep, '.git', 'hooks', HOOK_NAME);
 
 export const isHookCalled = process.argv[1].endsWith(`${SYMLINK_URL}`);
 


### PR DESCRIPTION
The `SYMLINK_URL` has been updated to fix an issue with the CLI tool that caused it to crash on Windows environments with the error message "SystemError [ERR_TTY_INIT_FAILED]: TTY initialization failed: uv_tty_init returned EBADF (bad file descriptor)".