### PR TITLE
🔥 refactor(githook.ts): remove unused import

### DIFF
--- a/src/commands/githook.ts
+++ b/src/commands/githook.ts
@@ -6,7 +6,6 @@ import { existsSync } from 'fs';
 import chalk from 'chalk';
 import { intro, outro } from '@clack/prompts';
 import { COMMANDS } from '../CommandsEnum.js';
-import { fileURLToPath } from 'url';
 
 const HOOK_NAME = 'prepare-commit-msg';
 const SYMLINK_URL = `.git/hooks/${HOOK_NAME}`;


### PR DESCRIPTION
The import statement for the fileURLToPath function from the url module is not used in the file. Therefore, it has been removed to improve code readability and maintainability.