### PR TITLE
Allow for commit prefix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@dqbd/tiktoken": "^1.0.2",
         "axios": "^1.3.4",
         "chalk": "^5.2.0",
+        "child_process": "^1.0.2",
         "cleye": "^1.3.2",
         "execa": "^7.0.0",
         "ignore": "^5.2.4",
@@ -733,6 +734,11 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+    },
+    "node_modules/child_process": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
+      "integrity": "sha512-Wmza/JzL0SiWz7kl6MhIKT5ceIlnFPJX+lwUGj7Clhy5MMldsSoJR0+uvRzOS5Kv45Mq7t1PoE8TsOA9bzvb6g=="
     },
     "node_modules/cleye": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@dqbd/tiktoken": "^1.0.2",
     "axios": "^1.3.4",
     "chalk": "^5.2.0",
+    "child_process": "^1.0.2",
     "cleye": "^1.3.2",
     "execa": "^7.0.0",
     "ignore": "^5.2.4",

--- a/src/api.ts
+++ b/src/api.ts
@@ -59,7 +59,11 @@ class OpenAi {
 
       const message = data.choices[0].message;
 
-      return message?.content;
+      const prefix = generatePrefix();
+
+      const finalMessage = (prefix || '') + (message?.content || '');
+      
+      return finalMessage;
     } catch (error: unknown) {
       outro(`${chalk.red('✖')} ${error}`);
 
@@ -94,4 +98,12 @@ export const getOpenCommitLatestVersion = async (): Promise<
   }
 };
 
+function generatePrefix(): string | undefined {
+  if (!config?.prefix) {
+    return undefined;
+  }
+  return config.prefix;
+}
+
 export const api = new OpenAi();
+

--- a/src/api.ts
+++ b/src/api.ts
@@ -61,7 +61,7 @@ class OpenAi {
 
       const prefix = generatePrefix();
 
-      const finalMessage = (prefix || '') + (message?.content || '');
+      const finalMessage = (prefix ? prefix + ' ' : '') + (message?.content || '')
       
       return finalMessage;
     } catch (error: unknown) {

--- a/src/api.ts
+++ b/src/api.ts
@@ -99,10 +99,10 @@ export const getOpenCommitLatestVersion = async (): Promise<
 };
 
 function generatePrefix(): string | undefined {
-  if (!config?.prefix) {
+  if (!config?.prefix !== undefined) {
     return undefined;
   }
-  return config.prefix;
+  return config?.prefix;
 }
 
 export const api = new OpenAi();

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -115,7 +115,7 @@ export const configValidators = {
   [CONFIG_KEYS.prefix](value: any) {
     validateConfig(
       CONFIG_KEYS.prefix,
-      value,
+      true,
       'Cannot be empty'
     );
     return value;

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -15,7 +15,8 @@ export enum CONFIG_KEYS {
   description = 'description',
   emoji = 'emoji',
   model = 'model',
-  language = 'language'
+  language = 'language',
+  prefix = 'prefix'
 }
 
 export enum CONFIG_MODES {
@@ -109,7 +110,17 @@ export const configValidators = {
       `${value} is not supported yet, use 'gpt-4' or 'gpt-3.5-turbo' (default)`
     );
     return value;
+  },
+
+  [CONFIG_KEYS.prefix](value: any) {
+    validateConfig(
+      CONFIG_KEYS.prefix,
+      value,
+      'Cannot be empty'
+    );
+    return value;
   }
+
 };
 
 export type ConfigType = {


### PR DESCRIPTION
A new configuration option called "prefix" has been added. This option allows you to set a default prefix for each commit. It also supports regular expressions (regex) to match the prefix against the branch name.

Here is a simple example of using the prefix option:

oc config set prefix amyu98-commit:

This will result in:

amyu98-commit: Some lovely AI commit content

Below is an example of using a basic regex with the prefix option:

oc config set prefix /^([a-zA-Z]+-\d+)/

For the local branch "DEV-12345-commit-prefix", this will result in:

DEV-12345: Some lovely AI commit content