### PR TITLE
🐛 fix(config.ts): convert string value to number in OPENAI_MAX_TOKENS…

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -65,6 +65,15 @@ export const configValidators = {
   },
 
   [CONFIG_KEYS.OPENAI_MAX_TOKENS](value: any) {
+    // If the value is a string, convert it to a number.
+    if (typeof value === 'string') {
+      value = parseInt(value);
+      validateConfig(
+        CONFIG_KEYS.OPENAI_MAX_TOKENS,
+        !isNaN(value),
+        'Must be a number'
+      );
+    }
     validateConfig(
       CONFIG_KEYS.OPENAI_MAX_TOKENS,
       typeof value === 'number',


### PR DESCRIPTION
… validator

The OPENAI_MAX_TOKENS validator now converts a string value to a number before validating it. This ensures that the validator works correctly when a string value is passed in.

#161 fixed