### PR TITLE
🐛 fix(config.ts): error message for OPENAI_BASE_PATH validation

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -96,8 +96,8 @@ export const configValidators = {
   [CONFIG_KEYS.OPENAI_BASE_PATH](value: any) {
     validateConfig(
       CONFIG_KEYS.OPENAI_BASE_PATH,
-      typeof value == 'string',
-      `${value} is not supported yet`
+      typeof value === 'string',
+      'Must be string'
     );
     return value;
   },


### PR DESCRIPTION
The error message for the OPENAI_BASE_PATH validation has been updated to be more descriptive and helpful. The message now reads "Must be string" instead of "${value} is not supported yet". This change improves the clarity of the error message and makes it easier for developers to understand what went wrong when the validation fails.

#163 fixing