### PR TITLE
OPENAI_MAX_TOKENS validation fix

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -67,7 +67,7 @@ export const configValidators = {
   [CONFIG_KEYS.OPENAI_MAX_TOKENS](value: any) {
     validateConfig(
       CONFIG_KEYS.OPENAI_MAX_TOKENS,
-      isNaN(+value),
+      typeof value === 'number' && !isNaN(+value),
       'Must be a number'
     );
 

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -67,7 +67,7 @@ export const configValidators = {
   [CONFIG_KEYS.OPENAI_MAX_TOKENS](value: any) {
     validateConfig(
       CONFIG_KEYS.OPENAI_MAX_TOKENS,
-      typeof value === 'number',
+      isNaN(+value),
       'Must be a number'
     );
 


### PR DESCRIPTION
fix config validation for OPENAI_MAX_TOKENS to check if value is not NaN instead of checking if it's a number