### PR TITLE
Correcting Typo in README - Updated 'oc' Shortcut to 'oco' Missed in Previous Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ You can also use the `oco` shortcut:
 
 ```sh
 git add <files...>
-oc
+oco
 ```
 
 ## Configuration


### PR DESCRIPTION
Hello exceptional maintainers! 🚀 

I've been having a blast learning and exploring this project and found something minor I could help with.

The README docs had a slight hiccup referring to the renamed shortcut. The document mentions `oc` in just **one** more spot where it should be `oco`. So, I took the liberty of fixing it. No change is too small, right? 😅 

The original fix #178, is the one that addressed this and that successfully closed issue #144. 

This pull request:
- Changes the 'oc' shortcut in the README to 'oco', aligning it with the rest of the project as per fix #178.

Keep up the incredible work, and happy coding! 💻🎉