### PR TITLE
✨ feat(config.ts): add OCO_EMOJI_POSITION_BEFORE_DESCRIPTION 

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ jobs:
           OCO_OPENAI_BASE_PATH: ''
           OCO_DESCRIPTION: false
           OCO_EMOJI: false
+          OCO_EMOJI_POSITION_BEFORE_DESCRIPTION: false
           OCO_MODEL: gpt-3.5-turbo
           OCO_LANGUAGE: en
 ```
@@ -123,6 +124,7 @@ OCO_OPENAI_MAX_TOKENS=<max response tokens from OpenAI API>
 OCO_OPENAI_BASE_PATH=<may be used to set proxy path to OpenAI api>
 OCO_DESCRIPTION=<postface a message with ~3 sentences description>
 OCO_EMOJI=<add GitMoji>
+OCO_EMOJI_POSITION_BEFORE_DESCRIPTION=<add GitMoji beofre description>
 OCO_MODEL=<either gpt-3.5-turbo or gpt-4>
 OCO_LANGUAGE=<locale, scroll to the bottom to see options>
 OCO_MESSAGE_TEMPLATE_PLACEHOLDER=<message template placeholder, example: '$msg'>
@@ -148,6 +150,23 @@ To remove preface emojis:
 
 ```sh
 oco config set OCO_EMOJI=false
+```
+
+The GitMoji should be placed immediately before the description in the commit message.
+For example: "chore(ansible-lint.yml): 🔧 remove yaml[line-length] from skip_list".
+
+
+```sh
+oco config set OCO_EMOJI_POSITION_BEFORE_DESCRIPTION=true
+```
+
+
+The GitMoji should be placed at the start of the commit message.
+For example: "🔧 chore(ansible-lint.yml): remove yaml[line-length] from skip_list".
+
+
+```sh
+oco config set OCO_EMOJI_POSITION_BEFORE_DESCRIPTION=false
 ```
 
 ### Switch to GPT-4 or other models

--- a/out/cli.cjs
+++ b/out/cli.cjs
@@ -16272,7 +16272,7 @@ function G3(t, e2) {
 // package.json
 var package_default = {
   name: "opencommit",
-  version: "2.4.1",
+  version: "2.4.2",
   description: "Auto-generate impressive commits in 1 second. Killing lame commits with AI \u{1F92F}\u{1F52B}",
   keywords: [
     "git",
@@ -17657,6 +17657,14 @@ var configValidators = {
     );
     return value;
   },
+  ["OCO_EMOJI_POSITION_BEFORE_DESCRIPTION" /* OCO_EMOJI_POSITION_BEFORE_DESCRIPTION */](value) {
+    validateConfig(
+      "OCO_EMOJI_POSITION_BEFORE_DESCRIPTION" /* OCO_EMOJI_POSITION_BEFORE_DESCRIPTION */,
+      typeof value === "boolean",
+      "Must be true or false"
+    );
+    return value;
+  },
   ["OCO_LANGUAGE" /* OCO_LANGUAGE */](value) {
     validateConfig(
       "OCO_LANGUAGE" /* OCO_LANGUAGE */,
@@ -17703,6 +17711,7 @@ var getConfig = () => {
     OCO_OPENAI_BASE_PATH: process.env.OCO_OPENAI_BASE_PATH,
     OCO_DESCRIPTION: process.env.OCO_DESCRIPTION === "true" ? true : false,
     OCO_EMOJI: process.env.OCO_EMOJI === "true" ? true : false,
+    OCO_EMOJI_POSITION_BEFORE_DESCRIPTION: process.env.OCO_EMOJI_POSITION_BEFORE_DESCRIPTION === "true" ? true : false,
     OCO_MODEL: process.env.OCO_MODEL || "gpt-3.5-turbo-16k",
     OCO_LANGUAGE: process.env.OCO_LANGUAGE || "en",
     OCO_MESSAGE_TEMPLATE_PLACEHOLDER: process.env.OCO_MESSAGE_TEMPLATE_PLACEHOLDER || "$msg"
@@ -21803,6 +21812,7 @@ var INIT_MESSAGES_PROMPT = [
     role: import_openai2.ChatCompletionRequestMessageRoleEnum.System,
     content: `You are to act as the author of a commit message in git. Your mission is to create clean and comprehensive commit messages in the conventional commit convention and explain WHAT were the changes and WHY the changes were done. I'll send you an output of 'git diff --staged' command, and you convert it into a commit message.
 ${config3?.OCO_EMOJI ? "Use GitMoji convention to preface the commit." : "Do not preface the commit with anything."}
+${config3?.OCO_EMOJI_POSITION_BEFORE_DESCRIPTION ? 'The GitMoji should be placed immediately before the description in the commit message. For example: "chore(ansible-lint.yml): \u{1F527} remove yaml[line-length] from skip_list".' : 'The GitMoji should be placed at the start of the commit message. For example: "\u{1F527} chore(ansible-lint.yml): remove yaml[line-length] from skip_list".'}
 ${config3?.OCO_DESCRIPTION ? `Add a short description of WHY the changes are done after the commit message. Don't start it with "This commit", just describe the changes.` : "Don't add any descriptions to the commit, only commit message."}
 Use the present tense. Lines must not be longer than 74 characters. Use ${translation.localLanguage} to answer.`
   },
@@ -21835,9 +21845,9 @@ app.use((_, res, next) => {
   },
   {
     role: import_openai2.ChatCompletionRequestMessageRoleEnum.Assistant,
-    content: `${config3?.OCO_EMOJI ? "\u{1F41B} " : ""}${translation.commitFix}
-${config3?.OCO_EMOJI ? "\u2728 " : ""}${translation.commitFeat}
-${config3?.OCO_DESCRIPTION ? translation.commitDescription : ""}`
+    content: `${config3?.OCO_EMOJI ? config3?.OCO_EMOJI_POSITION_BEFORE_DESCRIPTION ? "fix(server.ts): \u{1F41B} " : "\u{1F41B} fix(server.ts): " : "fix(server.ts): "}${translation.commitFix.replace("fix(server.ts): ", "")}
+      ${config3?.OCO_EMOJI ? config3?.OCO_EMOJI_POSITION_BEFORE_DESCRIPTION ? "feat(server.ts): \u2728 " : "\u2728 feat(server.ts): " : "feat(server.ts): "}${translation.commitFeat.replace("feat(server.ts): ", "")}
+      ${config3?.OCO_DESCRIPTION ? translation.commitDescription : ""}`
   }
 ];
 var generateCommitMessageChatCompletionPrompt = (diff) => {

--- a/out/github-action.cjs
+++ b/out/github-action.cjs
@@ -27680,6 +27680,14 @@ var configValidators = {
     );
     return value;
   },
+  ["OCO_EMOJI_POSITION_BEFORE_DESCRIPTION" /* OCO_EMOJI_POSITION_BEFORE_DESCRIPTION */](value) {
+    validateConfig(
+      "OCO_EMOJI_POSITION_BEFORE_DESCRIPTION" /* OCO_EMOJI_POSITION_BEFORE_DESCRIPTION */,
+      typeof value === "boolean",
+      "Must be true or false"
+    );
+    return value;
+  },
   ["OCO_LANGUAGE" /* OCO_LANGUAGE */](value) {
     validateConfig(
       "OCO_LANGUAGE" /* OCO_LANGUAGE */,
@@ -27726,6 +27734,7 @@ var getConfig = () => {
     OCO_OPENAI_BASE_PATH: process.env.OCO_OPENAI_BASE_PATH,
     OCO_DESCRIPTION: process.env.OCO_DESCRIPTION === "true" ? true : false,
     OCO_EMOJI: process.env.OCO_EMOJI === "true" ? true : false,
+    OCO_EMOJI_POSITION_BEFORE_DESCRIPTION: process.env.OCO_EMOJI_POSITION_BEFORE_DESCRIPTION === "true" ? true : false,
     OCO_MODEL: process.env.OCO_MODEL || "gpt-3.5-turbo-16k",
     OCO_LANGUAGE: process.env.OCO_LANGUAGE || "en",
     OCO_MESSAGE_TEMPLATE_PLACEHOLDER: process.env.OCO_MESSAGE_TEMPLATE_PLACEHOLDER || "$msg"
@@ -28007,6 +28016,7 @@ var INIT_MESSAGES_PROMPT = [
     role: import_openai2.ChatCompletionRequestMessageRoleEnum.System,
     content: `You are to act as the author of a commit message in git. Your mission is to create clean and comprehensive commit messages in the conventional commit convention and explain WHAT were the changes and WHY the changes were done. I'll send you an output of 'git diff --staged' command, and you convert it into a commit message.
 ${config3?.OCO_EMOJI ? "Use GitMoji convention to preface the commit." : "Do not preface the commit with anything."}
+${config3?.OCO_EMOJI_POSITION_BEFORE_DESCRIPTION ? 'The GitMoji should be placed immediately before the description in the commit message. For example: "chore(ansible-lint.yml): \u{1F527} remove yaml[line-length] from skip_list".' : 'The GitMoji should be placed at the start of the commit message. For example: "\u{1F527} chore(ansible-lint.yml): remove yaml[line-length] from skip_list".'}
 ${config3?.OCO_DESCRIPTION ? `Add a short description of WHY the changes are done after the commit message. Don't start it with "This commit", just describe the changes.` : "Don't add any descriptions to the commit, only commit message."}
 Use the present tense. Lines must not be longer than 74 characters. Use ${translation.localLanguage} to answer.`
   },
@@ -28039,9 +28049,9 @@ app.use((_, res, next) => {
   },
   {
     role: import_openai2.ChatCompletionRequestMessageRoleEnum.Assistant,
-    content: `${config3?.OCO_EMOJI ? "\u{1F41B} " : ""}${translation.commitFix}
-${config3?.OCO_EMOJI ? "\u2728 " : ""}${translation.commitFeat}
-${config3?.OCO_DESCRIPTION ? translation.commitDescription : ""}`
+    content: `${config3?.OCO_EMOJI ? config3?.OCO_EMOJI_POSITION_BEFORE_DESCRIPTION ? "fix(server.ts): \u{1F41B} " : "\u{1F41B} fix(server.ts): " : "fix(server.ts): "}${translation.commitFix.replace("fix(server.ts): ", "")}
+      ${config3?.OCO_EMOJI ? config3?.OCO_EMOJI_POSITION_BEFORE_DESCRIPTION ? "feat(server.ts): \u2728 " : "\u2728 feat(server.ts): " : "feat(server.ts): "}${translation.commitFeat.replace("feat(server.ts): ", "")}
+      ${config3?.OCO_DESCRIPTION ? translation.commitDescription : ""}`
   }
 ];
 var generateCommitMessageChatCompletionPrompt = (diff) => {

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -18,6 +18,7 @@ export enum CONFIG_KEYS {
   OCO_OPENAI_BASE_PATH = 'OCO_OPENAI_BASE_PATH',
   OCO_DESCRIPTION = 'OCO_DESCRIPTION',
   OCO_EMOJI = 'OCO_EMOJI',
+  OCO_EMOJI_POSITION_BEFORE_DESCRIPTION = 'OCO_EMOJI_POSITION_BEFORE_DESCRIPTION',
   OCO_MODEL = 'OCO_MODEL',
   OCO_LANGUAGE = 'OCO_LANGUAGE',
   OCO_MESSAGE_TEMPLATE_PLACEHOLDER = 'OCO_MESSAGE_TEMPLATE_PLACEHOLDER'
@@ -100,6 +101,16 @@ export const configValidators = {
     return value;
   },
 
+  [CONFIG_KEYS.OCO_EMOJI_POSITION_BEFORE_DESCRIPTION](value: any) {
+    validateConfig(
+      CONFIG_KEYS.OCO_EMOJI_POSITION_BEFORE_DESCRIPTION,
+      typeof value === 'boolean',
+      'Must be true or false'
+    );
+
+    return value;
+  },
+
   [CONFIG_KEYS.OCO_LANGUAGE](value: any) {
     validateConfig(
       CONFIG_KEYS.OCO_LANGUAGE,
@@ -156,6 +167,7 @@ export const getConfig = (): ConfigType | null => {
     OCO_OPENAI_BASE_PATH: process.env.OCO_OPENAI_BASE_PATH,
     OCO_DESCRIPTION: process.env.OCO_DESCRIPTION === 'true' ? true : false,
     OCO_EMOJI: process.env.OCO_EMOJI === 'true' ? true : false,
+    OCO_EMOJI_POSITION_BEFORE_DESCRIPTION: process.env.OCO_EMOJI_POSITION_BEFORE_DESCRIPTION === 'true' ? true : false,
     OCO_MODEL: process.env.OCO_MODEL || 'gpt-3.5-turbo-16k',
     OCO_LANGUAGE: process.env.OCO_LANGUAGE || 'en',
     OCO_MESSAGE_TEMPLATE_PLACEHOLDER:

--- a/src/generateCommitMessageFromGitDiff.ts
+++ b/src/generateCommitMessageFromGitDiff.ts
@@ -17,6 +17,7 @@ const INIT_MESSAGES_PROMPT: Array<ChatCompletionRequestMessage> = [
     // prettier-ignore
     content: `You are to act as the author of a commit message in git. Your mission is to create clean and comprehensive commit messages in the conventional commit convention and explain WHAT were the changes and WHY the changes were done. I'll send you an output of 'git diff --staged' command, and you convert it into a commit message.
 ${config?.OCO_EMOJI ? 'Use GitMoji convention to preface the commit.' : 'Do not preface the commit with anything.'}
+${config?.OCO_EMOJI_POSITION_BEFORE_DESCRIPTION ? 'The GitMoji should be placed immediately before the description in the commit message. For example: "chore(ansible-lint.yml): 🔧 remove yaml[line-length] from skip_list".' : 'The GitMoji should be placed at the start of the commit message. For example: "🔧 chore(ansible-lint.yml): remove yaml[line-length] from skip_list".'}
 ${config?.OCO_DESCRIPTION ? 'Add a short description of WHY the changes are done after the commit message. Don\'t start it with "This commit", just describe the changes.' : "Don't add any descriptions to the commit, only commit message."}
 Use the present tense. Lines must not be longer than 74 characters. Use ${translation.localLanguage} to answer.`
   },

--- a/src/generateCommitMessageFromGitDiff.ts
+++ b/src/generateCommitMessageFromGitDiff.ts
@@ -50,9 +50,19 @@ app.use((_, res, next) => {
   },
   {
     role: ChatCompletionRequestMessageRoleEnum.Assistant,
-    content: `${config?.OCO_EMOJI ? '🐛 ' : ''}${translation.commitFix}
-${config?.OCO_EMOJI ? '✨ ' : ''}${translation.commitFeat}
-${config?.OCO_DESCRIPTION ? translation.commitDescription : ''}`
+    content: `${config?.OCO_EMOJI
+      ? (config?.OCO_EMOJI_POSITION_BEFORE_DESCRIPTION
+        ? 'fix(server.ts): 🐛 '
+        : '🐛 fix(server.ts): ')
+      : 'fix(server.ts): '
+      }${translation.commitFix.replace('fix(server.ts): ', '')}
+      ${config?.OCO_EMOJI
+        ? (config?.OCO_EMOJI_POSITION_BEFORE_DESCRIPTION
+          ? 'feat(server.ts): ✨ '
+          : '✨ feat(server.ts): ')
+        : 'feat(server.ts): '
+      }${translation.commitFeat.replace('feat(server.ts): ', '')}
+      ${config?.OCO_DESCRIPTION ? translation.commitDescription : ''}`
   }
 ];
 


### PR DESCRIPTION
Hello @di-sukharev,

I have submitted this pull request wherein I have made several amendments to your opencommit project.

1. I have introduced a new configuration key `OCO_EMOJI_POSITION_BEFORE_DESCRIPTION` that allows users to customise the position of the emoji within the commit message. This provides users with greater flexibility in formatting their commit messages.

2. I have updated the instructions within `generateCommitMessageFromGitDiff.ts` to reflect this new option.

3. I have also updated the `README.md` file to include instructions on how to utilise the `OCO_EMOJI_POSITION_BEFORE_DESCRIPTION` configuration. This configuration allows users to determine where the GitMoji should be placed within the commit message.

4. I have updated the assistant to accommodate the new `OCO_EMOJI_POSITION_BEFORE_DESCRIPTION` configuration. The assistant now generates commit messages based on the emoji position specified by the user.

5. Lastly, I have updated the package version from 2.4.1 to 2.4.2 to reflect these new modifications and improvements.

I would like to emphasise that I have tested these modifications locally and everything appears to be functioning as expected.

However, I would like to draw your attention to the fact that the documentation for contributing to the project is somewhat sparse. This could make access to contribution more challenging for new contributors. I believe it would be beneficial to enhance this aspect to facilitate community contribution.

Thank you for your time and consideration. I eagerly await your feedback on my pull request.

Close #219