### PR TITLE
Allow any leght of OCO_OPENAI_API_KEY when OCO_OPENAI_BASE_PATH value is set

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -45,7 +45,7 @@ const validateConfig = (
 };
 
 export const configValidators = {
-  [CONFIG_KEYS.OCO_OPENAI_API_KEY](value: any) {
+  [CONFIG_KEYS.OCO_OPENAI_API_KEY](value: any, config?: any) {
     validateConfig(CONFIG_KEYS.OCO_OPENAI_API_KEY, value, 'Cannot be empty');
     validateConfig(
       CONFIG_KEYS.OCO_OPENAI_API_KEY,
@@ -54,7 +54,7 @@ export const configValidators = {
     );
     validateConfig(
       CONFIG_KEYS.OCO_OPENAI_API_KEY,
-      value.length === 51,
+      config[CONFIG_KEYS.OCO_OPENAI_BASE_PATH] || value.length === 51,
       'Must be 51 characters long'
     );
 
@@ -179,7 +179,7 @@ export const getConfig = (): ConfigType | null => {
     try {
       const validator = configValidators[configKey as CONFIG_KEYS];
       const validValue = validator(
-        config[configKey] ?? configFromEnv[configKey as CONFIG_KEYS]
+        config[configKey] ?? configFromEnv[configKey as CONFIG_KEYS], config
       );
 
       config[configKey] = validValue;


### PR DESCRIPTION
In my company we use dedicated proxy server for OpenAI API requests, so my API KEY has shorter length that validation allows. This fix allow any length of OCO_OPENAI_API_KEY if OCO_OPENAI_BASE_PATH key is set to other value