### PR TITLE
Feat: one line commit, even if multiple file changes

### DIFF
--- a/out/github-action.cjs
+++ b/out/github-action.cjs
@@ -27990,6 +27990,14 @@ var configValidators = {
       `${value} is not supported yet, use '@commitlint' or 'conventional-commit' (default)`
     );
     return value;
+  },
+  ["OCO_ONE_LINE_COMMIT" /* OCO_ONE_LINE_COMMIT */](value) {
+    validateConfig(
+      "OCO_ONE_LINE_COMMIT" /* OCO_ONE_LINE_COMMIT */,
+      typeof value === "boolean",
+      "Must be true or false"
+    );
+    return value;
   }
 };
 var configPath = (0, import_path.join)((0, import_os.homedir)(), ".opencommit");
@@ -28003,7 +28011,8 @@ var getConfig = () => {
     OCO_MODEL: process.env.OCO_MODEL || "gpt-3.5-turbo-16k",
     OCO_LANGUAGE: process.env.OCO_LANGUAGE || "en",
     OCO_MESSAGE_TEMPLATE_PLACEHOLDER: process.env.OCO_MESSAGE_TEMPLATE_PLACEHOLDER || "$msg",
-    OCO_PROMPT_MODULE: process.env.OCO_PROMPT_MODULE || "conventional-commit"
+    OCO_PROMPT_MODULE: process.env.OCO_PROMPT_MODULE || "conventional-commit",
+    OCO_ONE_LINE_COMMIT: process.env.OCO_ONE_LINE_COMMIT === "true" ? true : false
   };
   const configExists = (0, import_fs.existsSync)(configPath);
   if (!configExists)
@@ -28141,6 +28150,24 @@ var OpenAi = class {
       }
       const { data } = await this.openAI.createChatCompletion(params);
       const message = data.choices[0].message;
+      if (config2?.OCO_ONE_LINE_COMMIT) {
+        const { data: oneLineData } = await this.openAI.createChatCompletion({
+          ...params,
+          messages: [
+            {
+              role: "system",
+              content: messages[0].content + "Summarize all file changes in one commit message, Highlight key changes and mention a common scope if applicable, DO ABSOLUTELY NOT WRITE MULTIPLE SCOPES, omit scope if no shared theme exists."
+            },
+            {
+              role: "user",
+              content: `Here are commits messages:
+${message?.content}`
+            }
+          ]
+        });
+        const oneLineMessage = oneLineData.choices[0].message;
+        return oneLineMessage?.content;
+      }
       return message?.content;
     } catch (error) {
       ce(`${source_default.red("\u2716")} ${JSON.stringify(params)}`);

--- a/src/api.ts
+++ b/src/api.ts
@@ -76,6 +76,27 @@ class OpenAi {
 
       const message = data.choices[0].message;
 
+      if (config?.OCO_ONE_LINE_COMMIT) {
+        const { data: oneLineData } = await this.openAI.createChatCompletion({
+          ...params,
+          messages: [
+            {
+              role: 'system',
+              content:
+                messages[0].content +
+                'Summarize all file changes in one commit message, Highlight key changes and mention a common scope if applicable, DO ABSOLUTELY NOT WRITE MULTIPLE SCOPES, omit scope if no shared theme exists.'
+            },
+            {
+              role: 'user',
+              content: `Here are commits messages:\n${message?.content}`
+            }
+          ]
+        });
+
+        const oneLineMessage = oneLineData.choices[0].message;
+        return oneLineMessage?.content;
+      }
+
       return message?.content;
     } catch (error) {
       outro(`${chalk.red('✖')} ${JSON.stringify(params)}`);

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -22,7 +22,8 @@ export enum CONFIG_KEYS {
   OCO_MODEL = 'OCO_MODEL',
   OCO_LANGUAGE = 'OCO_LANGUAGE',
   OCO_MESSAGE_TEMPLATE_PLACEHOLDER = 'OCO_MESSAGE_TEMPLATE_PLACEHOLDER',
-  OCO_PROMPT_MODULE = 'OCO_PROMPT_MODULE'
+  OCO_PROMPT_MODULE = 'OCO_PROMPT_MODULE',
+  OCO_ONE_LINE_COMMIT = 'OCO_ONE_LINE_COMMIT'
 }
 
 export const DEFAULT_MODEL_TOKEN_LIMIT = 4096;
@@ -150,6 +151,16 @@ export const configValidators = {
     );
 
     return value;
+  },
+
+  [CONFIG_KEYS.OCO_ONE_LINE_COMMIT](value: any) {
+    validateConfig(
+      CONFIG_KEYS.OCO_ONE_LINE_COMMIT,
+      typeof value === 'boolean',
+      'Must be true or false'
+    );
+
+    return value;
   }
 };
 
@@ -172,7 +183,9 @@ export const getConfig = (): ConfigType | null => {
     OCO_LANGUAGE: process.env.OCO_LANGUAGE || 'en',
     OCO_MESSAGE_TEMPLATE_PLACEHOLDER:
       process.env.OCO_MESSAGE_TEMPLATE_PLACEHOLDER || '$msg',
-    OCO_PROMPT_MODULE: process.env.OCO_PROMPT_MODULE || 'conventional-commit'
+    OCO_PROMPT_MODULE: process.env.OCO_PROMPT_MODULE || 'conventional-commit',
+    OCO_ONE_LINE_COMMIT:
+      process.env.OCO_ONE_LINE_COMMIT === 'true' ? true : false
   };
 
   const configExists = existsSync(configPath);


### PR DESCRIPTION
Implement a new feature to support one-line commit messages. This change provides users with the flexibility to choose their preferred commit message format.

BEFORE
```
feat(deno.jsonc): add compilerOptions with jsx set to react for JSX support
style(schema.test.ts): reorder imports to follow alphabetical order
feat(schema.test.ts): add console log to track test case execution
feat(schema.ts): add findByIds function to fetch multiple records by ids
refactor(schema.ts): remove unnecessary ts-expect-error comments
style(schema.ts): add blank lines for better code readability
```

AFTER
```
feat(schema): Improve data retrieval and debugging

- Add `compilerOptions` with `jsx` set to `react` in `deno.jsonc` for JSX support
- Reorder imports alphabetically in `schema.test.ts` for better readability
- Add console log in test in `schema.test.ts` for better debugging
- Add `findByIds` function in `schema.ts` to fetch multiple records by their ids for improved data retrieval
```


### IMPORTANT
I have been using this PR for my commit messages in personal and professional projects and I would like to say that 
> The commit messages occasionally do not accurately reflect the associated diffs.

So @di-sukharev before proceeding with the merge, could you please conduct thorough testing across diverse scenarios and feel free to make necessary enhancements to ensure reliability.