### PR TITLE
(fix commit.ts) Remove messageTemplate from extraArgs to prevent git Error

### DIFF
--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -54,6 +54,9 @@ const generateCommitMessageFromGitDiff = async (
       config?.OCO_MESSAGE_TEMPLATE_PLACEHOLDER &&
       typeof messageTemplate === 'string'
     ) {
+      const messageTemplateIndex = extraArgs.indexOf(messageTemplate);
+      extraArgs.splice(messageTemplateIndex, 1);
+
       commitMessage = messageTemplate.replace(
         config?.OCO_MESSAGE_TEMPLATE_PLACEHOLDER,
         commitMessage


### PR DESCRIPTION
commit.ts : Remove messageTemplate from extraArgs to prevent git Error to fix this bug : 

https://github.com/di-sukharev/opencommit/issues/278

extraArgs contains all git extra flag but also the user custom message when use $msg.

For exemple oco '#11 $msg' return a bad git command

`git commit -m #11 generated_message #11 $msg`

This fix change remove the template message from extraArgs to generate this correct command : 

`git commit -m #11 generated_message`
