### PR TITLE
feat: #289 - Add possibility to skip git push question by setting `OCO_ASK_GIT_PUSH` config var

### DIFF
--- a/out/cli.cjs
+++ b/out/cli.cjs
@@ -16384,7 +16384,7 @@ function G3(t, e2) {
 // package.json
 var package_default = {
   name: "opencommit",
-  version: "3.0.10",
+  version: "3.0.11",
   description: "Auto-generate impressive commits in 1 second. Killing lame commits with AI \u{1F92F}\u{1F52B}",
   keywords: [
     "git",
@@ -22661,7 +22661,7 @@ var hookCommand = G3(
         return ce(`${source_default.green("\u2714")} Hook is removed`);
       }
       throw new Error(
-        `Unsupported mode: ${mode2}. Supported modes are: 'set' or 'unset'`
+        `Unsupported mode: ${mode2}. Supported modes are: 'set' or 'unset', do: \`oco hook set\``
       );
     } catch (error) {
       ce(`${source_default.red("\u2716")} ${error}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencommit",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencommit",
-      "version": "3.0.10",
+      "version": "3.0.11",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencommit",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "description": "Auto-generate impressive commits in 1 second. Killing lame commits with AI 🤯🔫",
   "keywords": [
     "git",


### PR DESCRIPTION
Feature Request : #289

## Description
When making multiple commits it is time-consuming to skip the "Do you want to run git push?" question each time.
I can assume people (and I) don't want to make a push for each separate commit.

## Suggested Solution
have a `oco config set OCO_ASK_GIT_PUSH=true` or `oco config set OCO_ASK_GIT_PUSH=false` (`true` by default)

## Expected :
- show the "Do you want to run git push?" on `true`
- don't show on `false`

