### PR TITLE
Bug (commitling) Parse JSON blocks from return response

### DIFF
--- a/src/modules/commitlint/config.ts
+++ b/src/modules/commitlint/config.ts
@@ -60,6 +60,16 @@ export const configureCommitlintIntegration = async (force = false) => {
 
   // Cleanup the consistency answer. Sometimes 'gpt-3.5-turbo' sends rule's back.
   prompts.forEach((prompt) => (consistency = consistency.replace(prompt, '')));
+
+  // sometimes consistency is preceded by explanatory text like "Here is your JSON:"
+  // note this could be surfaced in utils
+  const jsonIndex = consistency.search('```json');
+  if(jsonIndex > -1) {
+    consistency = consistency.slice(jsonIndex + 8);
+    const endJsonIndex = consistency.search('```');
+    consistency = consistency.slice(0, endJsonIndex); 
+  }
+  
   // ... remaining might be extra set of "\n"
   consistency = utils.removeDoubleNewlines(consistency);
 

--- a/src/modules/commitlint/config.ts
+++ b/src/modules/commitlint/config.ts
@@ -62,13 +62,7 @@ export const configureCommitlintIntegration = async (force = false) => {
   prompts.forEach((prompt) => (consistency = consistency.replace(prompt, '')));
 
   // sometimes consistency is preceded by explanatory text like "Here is your JSON:"
-  // note this could be surfaced in utils
-  const jsonIndex = consistency.search('```json');
-  if(jsonIndex > -1) {
-    consistency = consistency.slice(jsonIndex + 8);
-    const endJsonIndex = consistency.search('```');
-    consistency = consistency.slice(0, endJsonIndex); 
-  }
+  consistency = utils.getJSONBlock(consistency);
   
   // ... remaining might be extra set of "\n"
   consistency = utils.removeDoubleNewlines(consistency);

--- a/src/modules/commitlint/utils.ts
+++ b/src/modules/commitlint/utils.ts
@@ -16,6 +16,16 @@ export const removeDoubleNewlines = (input: string): string => {
   return input;
 };
 
+export const getJSONBlock = (input: string): string => {
+  const jsonIndex = input.search('```json');
+  if(jsonIndex > -1) {
+    input = input.slice(jsonIndex + 8);
+    const endJsonIndex = consistency.search('```');
+    input = input.slice(0, endJsonIndex); 
+  }
+  return input;
+};
+  
 export const commitlintLLMConfigExists = async (): Promise<boolean> => {
   let exists;
   try {
@@ -44,4 +54,4 @@ export const getCommitlintLLMConfig =
       content.toString()
     ) as CommitlintLLMConfig;
     return commitLintLLMConfig;
-  };
+};


### PR DESCRIPTION
Sometimes GPT responds with additional text before surfacing the JSON block. 

It is also worth noting that the config is still subject to `OCO_OPENAI_MAX_TOKENS` rules which may also cause the result to be truncated. Most likely we should be ignoring the MAX_TOKEN limit when fetching the config.