### PR TITLE
feat: add OCO_ONE_LINE_COMMIT config for concise commit messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ OCO_MODEL=<either 'gpt-4', 'gpt-3.5-turbo' (default), 'gpt-3.5-turbo-0125', 'gpt
 OCO_LANGUAGE=<locale, scroll to the bottom to see options>
 OCO_MESSAGE_TEMPLATE_PLACEHOLDER=<message template placeholder, default: '$msg'>
 OCO_PROMPT_MODULE=<either conventional-commit or @commitlint, default: conventional-commit>
+OCO_ONE_LINE_COMMIT=<one line commit message, default: false>
 ```
 
 ### Global config for all repos

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -25,6 +25,7 @@ export enum CONFIG_KEYS {
   OCO_MESSAGE_TEMPLATE_PLACEHOLDER = 'OCO_MESSAGE_TEMPLATE_PLACEHOLDER',
   OCO_PROMPT_MODULE = 'OCO_PROMPT_MODULE',
   OCO_AI_PROVIDER = 'OCO_AI_PROVIDER',
+  OCO_ONE_LINE_COMMIT = 'OCO_ONE_LINE_COMMIT'
 }
 
 export enum CONFIG_MODES {
@@ -195,6 +196,16 @@ export const configValidators = {
     );
     return value;
   },
+
+  [CONFIG_KEYS.OCO_ONE_LINE_COMMIT](value: any) {
+    validateConfig(
+      CONFIG_KEYS.OCO_ONE_LINE_COMMIT,
+      typeof value === 'boolean',
+      'Must be true or false'
+    );
+
+    return value;
+  },
 };
 
 export type ConfigType = {
@@ -220,7 +231,8 @@ export const getConfig = (): ConfigType | null => {
     OCO_MESSAGE_TEMPLATE_PLACEHOLDER:
       process.env.OCO_MESSAGE_TEMPLATE_PLACEHOLDER || '$msg',
     OCO_PROMPT_MODULE: process.env.OCO_PROMPT_MODULE || 'conventional-commit',
-    OCO_AI_PROVIDER: process.env.OCO_AI_PROVIDER || 'openai'
+    OCO_AI_PROVIDER: process.env.OCO_AI_PROVIDER || 'openai',
+    OCO_ONE_LINE_COMMIT: process.env.OCO_ONE_LINE_COMMIT === 'true' ? true : false
   };
 
   const configExists = existsSync(configPath);

--- a/src/modules/commitlint/prompts.ts
+++ b/src/modules/commitlint/prompts.ts
@@ -267,6 +267,7 @@ const INIT_MAIN_PROMPT = (
 ${config?.OCO_EMOJI ? 'Use GitMoji convention to preface the commit.' : 'Do not preface the commit with anything.'}
 ${config?.OCO_DESCRIPTION ? 'Add a short description of WHY the changes are done after the commit message. Don\'t start it with "This commit", just describe the changes.' : "Don't add any descriptions to the commit, only commit message."}
 Use the present tense. Use ${language} to answer.
+${ config?.OCO_ONE_LINE_COMMIT ? 'Craft a concise commit message that encapsulates all changes made, with an emphasis on the primary updates. If the modifications share a common theme or scope, mention it succinctly; otherwise, leave the scope out to maintain focus. The goal is to provide a clear and unified overview of the changes in a one single message, without diverging into a list of commit per file change.' : ""}
     
 You will strictly follow the following conventions to generate the content of the commit message:
 - ${prompts.join('\n- ')}

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -115,6 +115,11 @@ const INIT_MAIN_PROMPT = (
         ? 'Add a short description of WHY the changes are done after the commit message. Don\'t start it with "This commit", just describe the changes.'
         : "Don't add any descriptions to the commit, only commit message."
     }
+    ${
+      config?.OCO_ONE_LINE_COMMIT
+        ? 'Craft a concise commit message that encapsulates all changes made, with an emphasis on the primary updates. If the modifications share a common theme or scope, mention it succinctly; otherwise, leave the scope out to maintain focus. The goal is to provide a clear and unified overview of the changes in a one single message, without diverging into a list of commit per file change.'
+        : ""
+    }
     Use the present tense. Lines must not be longer than 74 characters. Use ${language} for the commit message.`
 });
 


### PR DESCRIPTION
- Introduce OCO_ONE_LINE_COMMIT option to enable crafting of concise, unified commit messages.
- Update README.md, config.ts, and prompts in commitlint and main prompts to support and validate the new configuration.
- Extend AI provider options with 'gpt-4-0125-preview'.