### PR TITLE
🐛 bug fix(cli.ts): properly handle the 'fgm' flag argument.

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,7 +29,7 @@ cli(
     if (await isHookCalled()) {
       prepareCommitMessageHook();
     } else {
-      commit(extraArgs, flags.fgm);
+      commit(extraArgs, false, flags.fgm);
     }
   },
   extraArgs


### PR DESCRIPTION
This PR is for fixing the bug with the 'fgm' flag.

### Current Bug
When executing the ```oco``` command using the ```--fgm``` flag, the value of the ```fgm``` flag is not correctly reflected. Instead, ```isStageAllFlag``` is mistakenly treated as true.

### Cause of the Bug
This is because, in the following commit, the order of arguments in the 'commit' function changed, but this was not reflected in the arguments at the call site.

https://github.com/di-sukharev/opencommit/commit/a33027b4db60bf7d16fc3e794e2a3e4cbc540330

```javascript
// File: commands/commit.ts

export async function commit(
  extraArgs: string[] = [],
  isStageAllFlag: Boolean = false,
  fullGitMojiSpec: boolean = false
) {
  if (isStageAllFlag) {
    ...
}

// File: cli.ts
commit(extraArgs, flags.fgm); // The value of 'flags.fgm' is being passed to 'isStageAllFlag'
```

### Changes
* Made sure the ```fgm``` flag argument is correctly passed to the ```commands/commit``` function in the ```cli``` file.
* Fixed the issue of passing the value of the ```fgm``` flag to ```isStageAllFlag```

### Note
If possible, how about handling optional arguments like this with object destructuring assignment?
When there are multiple optional arguments, you can pass only the arguments you want to pass without being aware of the order of the option keys, and it is extensible even when options increase.

```javascript
// File: commands/commit.ts

export async function commit(
  extraArgs: string[] = [],
  {
    isStageAllFlag = false,
    fullGitMojiSpec = false,
  }: {
    isStageAllFlag?: Boolean;
    fullGitMojiSpec?: Boolean;
  }
) {
  if (isStageAllFlag) {
    ...
}

// File: cli.ts
commit(extraArgs, { fullGitMojiSpec: flags.fgm });
```

Best regards