### PR TITLE
✅ fix the broken E2E tests due to the addition of OCO_GITPUSH

### DIFF
--- a/out/github-action.cjs
+++ b/out/github-action.cjs
@@ -24244,10 +24244,11 @@ var configValidators = {
         "gpt-3.5-turbo-0125",
         "gpt-4",
         "gpt-4-1106-preview",
-        "gpt-4-turbo-preview",
-        "gpt-4-0125-preview"
+        "gpt-4-0125-preview",
+        "gpt-4-turbo",
+        "gpt-4-turbo-preview"
       ].includes(value),
-      `${value} is not supported yet, use 'gpt-4', 'gpt-3.5-turbo' (default), 'gpt-3.5-turbo-0125', 'gpt-4-1106-preview', 'gpt-4-turbo-preview' or 'gpt-4-0125-preview'`
+      `${value} is not supported yet, use 'gpt-4', 'gpt-4-turbo', 'gpt-3.5-turbo' (default), 'gpt-3.5-turbo-0125', 'gpt-4-1106-preview', 'gpt-4-0125-preview' or 'gpt-4-turbo-preview'`
     );
     return value;
   },
@@ -24264,6 +24265,14 @@ var configValidators = {
       "OCO_PROMPT_MODULE" /* OCO_PROMPT_MODULE */,
       ["conventional-commit", "@commitlint"].includes(value),
       `${value} is not supported yet, use '@commitlint' or 'conventional-commit' (default)`
+    );
+    return value;
+  },
+  ["OCO_GITPUSH" /* OCO_GITPUSH */](value) {
+    validateConfig(
+      "OCO_GITPUSH" /* OCO_GITPUSH */,
+      typeof value === "boolean",
+      "Must be true or false"
     );
     return value;
   },
@@ -24303,6 +24312,7 @@ var getConfig = () => {
     OCO_MESSAGE_TEMPLATE_PLACEHOLDER: process.env.OCO_MESSAGE_TEMPLATE_PLACEHOLDER || "$msg",
     OCO_PROMPT_MODULE: process.env.OCO_PROMPT_MODULE || "conventional-commit",
     OCO_AI_PROVIDER: process.env.OCO_AI_PROVIDER || "openai",
+    OCO_GITPUSH: process.env.OCO_GITPUSH === "false" ? false : true,
     OCO_ONE_LINE_COMMIT: process.env.OCO_ONE_LINE_COMMIT === "true" ? true : false
   };
   const configExists = (0, import_fs.existsSync)(configPath);
@@ -24311,7 +24321,7 @@ var getConfig = () => {
   const configFile = (0, import_fs.readFileSync)(configPath, "utf8");
   const config7 = (0, import_ini.parse)(configFile);
   for (const configKey of Object.keys(config7)) {
-    if (!config7[configKey] || ["null", "undefined"].includes(config7[configKey])) {
+    if (["null", "undefined"].includes(config7[configKey])) {
       config7[configKey] = void 0;
       continue;
     }

--- a/test/e2e/oneFile.test.ts
+++ b/test/e2e/oneFile.test.ts
@@ -18,7 +18,7 @@ it('cli flow to generate commit message for 1 new file (staged)', async () => {
   expect(await findByText('Confirm the commit message?')).toBeInTheConsole();
   userEvent.keyboard('[Enter]');
 
-  expect(await findByText('Do you want to run `git push`?')).toBeInTheConsole();
+  expect(await findByText('Choose a remote to push to')).toBeInTheConsole();
   userEvent.keyboard('[Enter]');
 
   expect(await findByText('Successfully pushed all commits to origin')).toBeInTheConsole();
@@ -47,7 +47,7 @@ it('cli flow to generate commit message for 1 changed file (not staged)', async 
 
   expect(await findByText('Successfully committed')).toBeInTheConsole();
 
-  expect(await findByText('Do you want to run `git push`?')).toBeInTheConsole();
+  expect(await findByText('Choose a remote to push to')).toBeInTheConsole();
   userEvent.keyboard('[Enter]');
 
   expect(await findByText('Successfully pushed all commits to origin')).toBeInTheConsole();


### PR DESCRIPTION
I have fixed the E2E tests that were broken in recent commits.
The flow of asking about ```git push``` after commit has been changed with the addition of ```OCO_GITPUSH``` in the following PR: https://github.com/di-sukharev/opencommit/pull/220

### Changes
I have updated the expected values of the E2E tests to align with the latest flow.

### Test Execution
- ```npm run test:e2e:docker``` (recommended)
- ```npm run test:e2e``` (caution required for execution)
  - **It doesn't work if there is a global configuration file** (~/.opencommit)
  - There is a bug in the getConfig method. If a global configuration file exists, it does not return default settings for keys not listed in the configuration file. As a result, the flow of this ```git push``` changes and E2E test failed.