### PR TITLE
Add an environment variable to hold ollama instance

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -10,6 +10,7 @@ import { intro, outro } from '@clack/prompts';
 
 import { COMMANDS } from '../CommandsEnum';
 import { getI18nLocal } from '../i18n';
+import { isValidHttpUrl } from '../modules/commitlint/utils';
 
 dotenv.config();
 
@@ -25,6 +26,7 @@ export enum CONFIG_KEYS {
   OCO_MESSAGE_TEMPLATE_PLACEHOLDER = 'OCO_MESSAGE_TEMPLATE_PLACEHOLDER',
   OCO_PROMPT_MODULE = 'OCO_PROMPT_MODULE',
   OCO_AI_PROVIDER = 'OCO_AI_PROVIDER',
+  OCO_AI_HOST = 'OCO_AI_HOST',
   OCO_ONE_LINE_COMMIT = 'OCO_ONE_LINE_COMMIT'
 }
 
@@ -197,6 +199,15 @@ export const configValidators = {
     return value;
   },
 
+  [CONFIG_KEYS.OCO_AI_HOST](value: any) {
+    validateConfig(
+      CONFIG_KEYS.OCO_AI_HOST,
+      isValidHttpUrl(value),
+      `${value} is not a proper URL`
+    );
+    return value;
+  },
+
   [CONFIG_KEYS.OCO_ONE_LINE_COMMIT](value: any) {
     validateConfig(
       CONFIG_KEYS.OCO_ONE_LINE_COMMIT,
@@ -232,6 +243,7 @@ export const getConfig = (): ConfigType | null => {
       process.env.OCO_MESSAGE_TEMPLATE_PLACEHOLDER || '$msg',
     OCO_PROMPT_MODULE: process.env.OCO_PROMPT_MODULE || 'conventional-commit',
     OCO_AI_PROVIDER: process.env.OCO_AI_PROVIDER || 'openai',
+    OCO_AI_HOST: process.env.OCO_AI_HOST,
     OCO_ONE_LINE_COMMIT: process.env.OCO_ONE_LINE_COMMIT === 'true' ? true : false
   };
 

--- a/src/engine/ollama.ts
+++ b/src/engine/ollama.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosError } from 'axios';
 import { ChatCompletionRequestMessage } from 'openai';
 import { AiEngine } from './Engine';
+import { getConfig } from '../commands/config';
 
 export class OllamaAi implements AiEngine {
   async generateCommitMessage(
@@ -11,7 +12,9 @@ export class OllamaAi implements AiEngine {
     //console.log(messages);
     //process.exit()
 
-    const url = 'http://localhost:11434/api/chat';
+    const config = getConfig();
+
+    const url = `${config?.OCO_AI_HOST || "http://localhost:11434"}/api/chat`;
     const p = {
       model,
       messages,

--- a/src/modules/commitlint/utils.ts
+++ b/src/modules/commitlint/utils.ts
@@ -2,6 +2,7 @@ import fs from 'fs/promises';
 
 import { COMMITLINT_LLM_CONFIG_PATH } from './constants';
 import { CommitlintLLMConfig } from './types';
+import { URL } from "url";
 
 /**
  * Removes the "\n" only if occurring twice
@@ -55,3 +56,15 @@ export const getCommitlintLLMConfig =
     ) as CommitlintLLMConfig;
     return commitLintLLMConfig;
 };
+
+export const isValidHttpUrl = (url: string): boolean => {
+  let _url;
+
+  try {
+    _url = new URL(url);
+  } catch (_) {
+    return false;
+  }
+
+  return _url.protocol === "http:" || _url.protocol === "https:";
+}


### PR DESCRIPTION
…mmitlint/utils.ts):

- update hardcoded URLs with configurable OCO_AI_HOST variable
+ add isValidHttpUrl utility function to validate the OCO_AI_HOST value in utils.ts file
+ use getConfig() function from commands/config.ts to access OCO_AI_HOST and other config values
+ update OllamaAi class in engine/ollama.ts to use the new OCO_AI_HOST configuration value.

# Why ?

I tried the tool, and wanted to put `llama` on a personnal server.

I didn't give much time to test it, only generated this commit with the new `export OCO_AI_HOST='http://192.168.1.2:11434'`.

I'm not a typescript dev, so please be kind :smile: 