### PR TITLE
🐛bug fix: enable to use the new format of OpenAI's project API Key

### DIFF
--- a/out/cli.cjs
+++ b/out/cli.cjs
@@ -26936,7 +26936,7 @@ function G3(t2, e3) {
 // package.json
 var package_default = {
   name: "opencommit",
-  version: "3.0.13",
+  version: "3.0.14",
   description: "Auto-generate impressive commits in 1 second. Killing lame commits with AI \u{1F92F}\u{1F52B}",
   keywords: [
     "git",
@@ -29495,11 +29495,6 @@ var configValidators = {
       "OCO_OPENAI_API_KEY" /* OCO_OPENAI_API_KEY */,
       value.startsWith("sk-"),
       'Must start with "sk-"'
-    );
-    validateConfig(
-      "OCO_OPENAI_API_KEY" /* OCO_OPENAI_API_KEY */,
-      config9["OCO_OPENAI_BASE_PATH" /* OCO_OPENAI_BASE_PATH */] || value.length === 51,
-      "Must be 51 characters long"
     );
     return value;
   },

--- a/out/github-action.cjs
+++ b/out/github-action.cjs
@@ -48316,11 +48316,6 @@ var configValidators = {
       value.startsWith("sk-"),
       'Must start with "sk-"'
     );
-    validateConfig(
-      "OCO_OPENAI_API_KEY" /* OCO_OPENAI_API_KEY */,
-      config8["OCO_OPENAI_BASE_PATH" /* OCO_OPENAI_BASE_PATH */] || value.length === 51,
-      "Must be 51 characters long"
-    );
     return value;
   },
   ["OCO_ANTHROPIC_API_KEY" /* OCO_ANTHROPIC_API_KEY */](value, config8 = {}) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencommit",
-  "version": "3.0.13",
+  "version": "3.0.14",
   "description": "Auto-generate impressive commits in 1 second. Killing lame commits with AI 🤯🔫",
   "keywords": [
     "git",

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -92,11 +92,6 @@ export const configValidators = {
       value.startsWith('sk-'),
       'Must start with "sk-"'
     );
-    validateConfig(
-      CONFIG_KEYS.OCO_OPENAI_API_KEY,
-      config[CONFIG_KEYS.OCO_OPENAI_BASE_PATH] || value.length === 51,
-      'Must be 51 characters long'
-    );
 
     return value;
   },


### PR DESCRIPTION
This PR is a bug fix for Issue #326

## Background
OpenAI has introduced a new API key format:
* New format for project API keys
  - sk-proj-xxxx....xxxx (56 characters in length)
* Old format for API keys
  - sk-xxxx...xxxx (51 characters in length)

## Current Issue
When trying to use the new project API key, a validation error occurs due to the API key format check, which currently only accepts keys of 51 characters in length.

## Changes
Remove the validation related to the length of the API key.