### PR TITLE
docs: Corrected a Typographical Error in Configuration Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ All available languages are currently listed in the [i18n](https://github.com/di
 Pushing to git is on by default but if you would like to turn it off just use:
 
 ```sh
-oc config set OCO_GITPUSH=false
+oco config set OCO_GITPUSH=false
 ```
 
 ### Switch to `@commitlint`


### PR DESCRIPTION
# Corrected a Typographical Error in Configuration Command

## Summary
This pull request corrects a typographical error in the configuration command from `oc` to `oco`.

## Problem
The original command contained a typo:
```sh
oc config set OCO_GITPUSH=false
```

## Solution
The correct command should use `oco` instead of `oc`:
```sh
oco config set OCO_GITPUSH=false
```