### PR TITLE
Feature: Add command line flag --yes, -y to skip commit confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ This is due to limit the number of tokens sent in each request. However, if you 
 oco --fgm
 ```
 
+#### Skip Commit Confirmation
+
+This flag allows users to automatically commit the changes without having to manually confirm the commit message. This is useful for users who want to streamline the commit process and avoid additional steps. To use this flag, you can run the following command:
+
+```
+oco --yes
+```
+
 ## Configuration
 
 ### Local per repo configuration

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,7 +18,13 @@ cli(
     name: 'opencommit',
     commands: [configCommand, hookCommand, commitlintConfigCommand],
     flags: {
-      fgm: Boolean
+      fgm: Boolean,
+      yes: {
+        type: Boolean,
+        alias: 'y',
+        description: 'Skip commit confirmation prompt',
+        default: false
+      }
     },
     ignoreArgv: (type) => type === 'unknown-flag' || type === 'argument',
     help: { description: packageJSON.description }
@@ -29,7 +35,7 @@ cli(
     if (await isHookCalled()) {
       prepareCommitMessageHook();
     } else {
-      commit(extraArgs, false, flags.fgm);
+      commit(extraArgs, false, flags.fgm, flags.yes);
     }
   },
   extraArgs

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -41,7 +41,8 @@ const checkMessageTemplate = (extraArgs: string[]): string | false => {
 const generateCommitMessageFromGitDiff = async (
   diff: string,
   extraArgs: string[],
-  fullGitMojiSpec: boolean
+  fullGitMojiSpec: boolean,
+  skipCommitConfirmation: boolean
 ): Promise<void> => {
   await assertGitRepo();
   const commitSpinner = spinner();
@@ -76,7 +77,7 @@ ${commitMessage}
 ${chalk.grey('——————————————————')}`
     );
 
-    const isCommitConfirmedByUser = await confirm({
+    const isCommitConfirmedByUser = skipCommitConfirmation || await confirm({
       message: 'Confirm the commit message?'
     });
 
@@ -178,7 +179,8 @@ ${chalk.grey('——————————————————')}`
 export async function commit(
   extraArgs: string[] = [],
   isStageAllFlag: Boolean = false,
-  fullGitMojiSpec: boolean = false
+  fullGitMojiSpec: boolean = false,
+  skipCommitConfirmation: boolean = false
 ) {
   if (isStageAllFlag) {
     const changedFiles = await getChangedFiles();
@@ -250,7 +252,8 @@ export async function commit(
     generateCommitMessageFromGitDiff(
       await getDiff({ files: stagedFiles }),
       extraArgs,
-      fullGitMojiSpec
+      fullGitMojiSpec,
+      skipCommitConfirmation
     )
   );
 


### PR DESCRIPTION
## Changes

- Add `--yes, -y` flag to skip commit confirmation prompt.
- Document the `--yes` flag usage in README for user guidance.