### PR TITLE
Add new OpenAI models gpt-4o-mini and gpt-4o-mini-2024-07-18

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -44,7 +44,9 @@ export const MODEL_LIST = {
           'gpt-4-1106-preview',
           'gpt-4-turbo-preview',
           'gpt-4-0125-preview',
-          'gpt-4o'],
+          'gpt-4o',
+          'gpt-4o-mini',
+          'gpt-4o-mini-2024-07-18'],
 
   anthropic: ['claude-3-haiku-20240307',
               'claude-3-sonnet-20240229',


### PR DESCRIPTION
OpenAI releases new model gpt-4o-mini.
https://openai.com/index/gpt-4o-mini-advancing-cost-efficient-intelligence/