### PR TITLE
Add Gemini Pro Experimental Models

### DIFF
--- a/out/cli.cjs
+++ b/out/cli.cjs
@@ -32455,7 +32455,10 @@ var MODEL_LIST = {
   ],
   gemini: [
     "gemini-1.5-flash",
+    "gemini-1.5-flash-exp-0827",
     "gemini-1.5-pro",
+    "gemini-1.5-pro-exp-0801",
+    "gemini-1.5-pro-exp-0827",
     "gemini-1.0-pro",
     "gemini-pro-vision",
     "text-embedding-004"

--- a/out/github-action.cjs
+++ b/out/github-action.cjs
@@ -51262,7 +51262,10 @@ var MODEL_LIST = {
   ],
   gemini: [
     "gemini-1.5-flash",
+    "gemini-1.5-flash-exp-0827",
     "gemini-1.5-pro",
+    "gemini-1.5-pro-exp-0801",
+    "gemini-1.5-pro-exp-0827",
     "gemini-1.0-pro",
     "gemini-pro-vision",
     "text-embedding-004"

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -82,7 +82,10 @@ export const MODEL_LIST = {
 
   gemini: [
     'gemini-1.5-flash',
+    'gemini-1.5-flash-exp-0827',
     'gemini-1.5-pro',
+    'gemini-1.5-pro-exp-0801',
+    'gemini-1.5-pro-exp-0827',
     'gemini-1.0-pro',
     'gemini-pro-vision',
     'text-embedding-004'


### PR DESCRIPTION
**Description:**

This pull request adds support for new Gemini Pro experimental models to OpenCommit, expanding the range of available models for generating commit messages. The following models have been added to the `MODEL_LIST` in `src/commands/config.ts`:

- `gemini-1.5-pro-exp-0801`
- `gemini-1.5-pro-exp-0827`

**Motivation:**

The Gemini Pro experimental models offer potential improvements in performance and capabilities for generating commit messages. Adding them to OpenCommit provides users with more options and allows them to experiment with the latest advancements in Gemini models.

**Changes:**

- Updated `src/commands/config.ts` to include the new Gemini Pro experimental models in the `MODEL_LIST`.