### PR TITLE
🔧 Fixes regression introduced in ollama engine 

### DIFF
--- a/src/engine/ollama.ts
+++ b/src/engine/ollama.ts
@@ -28,7 +28,10 @@ export class OllamaAi implements AiEngine {
       stream: false
     };
     try {
-      const response = await this.client.post('', params);
+      const response = await this.client.post(
+        this.client.getUri(this.config),
+        params
+      );
 
       const message = response.data.message;
 


### PR DESCRIPTION
It looks like #391 refactoring broke ollama, using opencommit 3.1.1 with `OCO_AI_PROVIDER=ollama` will fail to connect displaying the following error:

```
┌  opencommit
│
○  Generating commit message
│
└  ✖ Error: Ollama provider error: Invalid URL

```