### PR TITLE
Feat/add user input code context

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,7 +18,7 @@ To get started, follow these steps:
 1. Clone the project repository locally.
 2. Install dependencies with `npm install`.
 3. Run the project with `npm run dev`.
-4. See [issues](https://github.com/di-sukharev/open-commit/issues) or [TODO.md](../TODO.md) to help the project.
+4. See [issues](https://github.com/di-sukharev/opencommit/issues) or [TODO.md](../TODO.md) to help the project.
 
 ## Commit message guidelines
 
@@ -30,7 +30,7 @@ If you encounter any issues while using the project, please report them on the G
 
 ## Contacts
 
-If you have any questions about contributing to the project, please contact by [creating an issue](https://github.com/di-sukharev/open-commit/issues) on the GitHub issue tracker.
+If you have any questions about contributing to the project, please contact by [creating an issue](https://github.com/di-sukharev/opencommit/issues) on the GitHub issue tracker.
 
 ## License
 

--- a/out/cli.cjs
+++ b/out/cli.cjs
@@ -45295,6 +45295,13 @@ var checkMessageTemplate = (extraArgs2) => {
   }
   return false;
 };
+var cleanupContext = (extraArgs2) => {
+  const index = extraArgs2.indexOf("--");
+  if (index !== -1) {
+    extraArgs2 = extraArgs2.slice(0, index);
+  }
+  return extraArgs2;
+};
 var generateCommitMessageFromGitDiff = async ({
   diff,
   extraArgs: extraArgs2,
@@ -45337,7 +45344,7 @@ ${source_default.grey("\u2014\u2014\u2014\u2014\u2014\u2014\u2014\u2014\u2014\u2
         "commit",
         "-m",
         commitMessage,
-        ...extraArgs2
+        ...cleanupContext(extraArgs2)
       ]);
       committingChangesSpinner.stop(
         `${source_default.green("\u2714")} Successfully committed`
@@ -45837,6 +45844,12 @@ Z2(
         alias: "y",
         description: "Skip commit confirmation prompt",
         default: false
+      },
+      context: {
+        type: String,
+        alias: "c",
+        description: "Context used to generate the commit message",
+        default: ""
       }
     },
     ignoreArgv: (type2) => type2 === "unknown-flag" || type2 === "argument",

--- a/out/cli.cjs
+++ b/out/cli.cjs
@@ -44931,6 +44931,19 @@ var CONVENTIONAL_COMMIT_KEYWORDS = "Do not preface the commit with anything, exc
 var getCommitConvention = (fullGitMojiSpec) => config4.OCO_EMOJI ? fullGitMojiSpec ? FULL_GITMOJI_SPEC : GITMOJI_HELP : CONVENTIONAL_COMMIT_KEYWORDS;
 var getDescriptionInstruction = () => config4.OCO_DESCRIPTION ? `Add a short description of WHY the changes are done after the commit message. Don't start it with "This commit", just describe the changes.` : "Don't add any descriptions to the commit, only commit message.";
 var getOneLineCommitInstruction = () => config4.OCO_ONE_LINE_COMMIT ? "Craft a concise commit message that encapsulates all changes made, with an emphasis on the primary updates. If the modifications share a common theme or scope, mention it succinctly; otherwise, leave the scope out to maintain focus. The goal is to provide a clear and unified overview of the changes in a one single message, without diverging into a list of commit per file change." : "";
+var userInputCodeContext = () => {
+  const args = process.argv;
+  const dashIndex = args.indexOf("--");
+  if (dashIndex !== -1) {
+    const context = args.slice(dashIndex + 1).join(" ");
+    if (context !== "" && context !== " ") {
+      return `Additional context provided by the user: ${context}
+
+Consider this context when generating the commit message, incorporating relevant information when appropriate.`;
+    }
+  }
+  return "";
+};
 var INIT_MAIN_PROMPT2 = (language, fullGitMojiSpec) => ({
   role: "system",
   content: (() => {
@@ -44941,12 +44954,14 @@ var INIT_MAIN_PROMPT2 = (language, fullGitMojiSpec) => ({
     const descriptionGuideline = getDescriptionInstruction();
     const oneLineCommitGuideline = getOneLineCommitInstruction();
     const generalGuidelines = `Use the present tense. Lines must not be longer than 74 characters. Use ${language} for the commit message.`;
+    const userInputContext = userInputCodeContext();
     return `${missionStatement}
 ${diffInstruction}
 ${conventionGuidelines}
 ${descriptionGuideline}
 ${oneLineCommitGuideline}
-${generalGuidelines}`;
+${generalGuidelines}
+${userInputContext}`;
   })()
 });
 var INIT_DIFF_PROMPT = {

--- a/out/github-action.cjs
+++ b/out/github-action.cjs
@@ -63732,6 +63732,19 @@ var CONVENTIONAL_COMMIT_KEYWORDS = "Do not preface the commit with anything, exc
 var getCommitConvention = (fullGitMojiSpec) => config4.OCO_EMOJI ? fullGitMojiSpec ? FULL_GITMOJI_SPEC : GITMOJI_HELP : CONVENTIONAL_COMMIT_KEYWORDS;
 var getDescriptionInstruction = () => config4.OCO_DESCRIPTION ? `Add a short description of WHY the changes are done after the commit message. Don't start it with "This commit", just describe the changes.` : "Don't add any descriptions to the commit, only commit message.";
 var getOneLineCommitInstruction = () => config4.OCO_ONE_LINE_COMMIT ? "Craft a concise commit message that encapsulates all changes made, with an emphasis on the primary updates. If the modifications share a common theme or scope, mention it succinctly; otherwise, leave the scope out to maintain focus. The goal is to provide a clear and unified overview of the changes in a one single message, without diverging into a list of commit per file change." : "";
+var userInputCodeContext = () => {
+  const args = process.argv;
+  const dashIndex = args.indexOf("--");
+  if (dashIndex !== -1) {
+    const context2 = args.slice(dashIndex + 1).join(" ");
+    if (context2 !== "" && context2 !== " ") {
+      return `Additional context provided by the user: ${context2}
+
+Consider this context when generating the commit message, incorporating relevant information when appropriate.`;
+    }
+  }
+  return "";
+};
 var INIT_MAIN_PROMPT2 = (language, fullGitMojiSpec) => ({
   role: "system",
   content: (() => {
@@ -63742,12 +63755,14 @@ var INIT_MAIN_PROMPT2 = (language, fullGitMojiSpec) => ({
     const descriptionGuideline = getDescriptionInstruction();
     const oneLineCommitGuideline = getOneLineCommitInstruction();
     const generalGuidelines = `Use the present tense. Lines must not be longer than 74 characters. Use ${language} for the commit message.`;
+    const userInputContext = userInputCodeContext();
     return `${missionStatement}
 ${diffInstruction}
 ${conventionGuidelines}
 ${descriptionGuideline}
 ${oneLineCommitGuideline}
-${generalGuidelines}`;
+${generalGuidelines}
+${userInputContext}`;
   })()
 });
 var INIT_DIFF_PROMPT = {

--- a/out/github-action.cjs
+++ b/out/github-action.cjs
@@ -63732,20 +63732,14 @@ var CONVENTIONAL_COMMIT_KEYWORDS = "Do not preface the commit with anything, exc
 var getCommitConvention = (fullGitMojiSpec) => config4.OCO_EMOJI ? fullGitMojiSpec ? FULL_GITMOJI_SPEC : GITMOJI_HELP : CONVENTIONAL_COMMIT_KEYWORDS;
 var getDescriptionInstruction = () => config4.OCO_DESCRIPTION ? `Add a short description of WHY the changes are done after the commit message. Don't start it with "This commit", just describe the changes.` : "Don't add any descriptions to the commit, only commit message.";
 var getOneLineCommitInstruction = () => config4.OCO_ONE_LINE_COMMIT ? "Craft a concise commit message that encapsulates all changes made, with an emphasis on the primary updates. If the modifications share a common theme or scope, mention it succinctly; otherwise, leave the scope out to maintain focus. The goal is to provide a clear and unified overview of the changes in a one single message, without diverging into a list of commit per file change." : "";
-var userInputCodeContext = () => {
-  const args = process.argv;
-  const dashIndex = args.indexOf("--");
-  if (dashIndex !== -1) {
-    const context2 = args.slice(dashIndex + 1).join(" ");
-    if (context2 !== "" && context2 !== " ") {
-      return `Additional context provided by the user: ${context2}
-
+var userInputCodeContext = (context2) => {
+  if (context2 !== "" && context2 !== " ") {
+    return `Additional context provided by the user: <context>${context2}</context>
 Consider this context when generating the commit message, incorporating relevant information when appropriate.`;
-    }
   }
   return "";
 };
-var INIT_MAIN_PROMPT2 = (language, fullGitMojiSpec) => ({
+var INIT_MAIN_PROMPT2 = (language, fullGitMojiSpec, context2) => ({
   role: "system",
   content: (() => {
     const commitConvention = fullGitMojiSpec ? "GitMoji specification" : "Conventional Commit Convention";
@@ -63755,7 +63749,7 @@ var INIT_MAIN_PROMPT2 = (language, fullGitMojiSpec) => ({
     const descriptionGuideline = getDescriptionInstruction();
     const oneLineCommitGuideline = getOneLineCommitInstruction();
     const generalGuidelines = `Use the present tense. Lines must not be longer than 74 characters. Use ${language} for the commit message.`;
-    const userInputContext = userInputCodeContext();
+    const userInputContext = userInputCodeContext(context2);
     return `${missionStatement}
 ${diffInstruction}
 ${conventionGuidelines}
@@ -63804,7 +63798,7 @@ var INIT_CONSISTENCY_PROMPT = (translation4) => ({
   role: "assistant",
   content: getContent(translation4)
 });
-var getMainCommitPrompt = async (fullGitMojiSpec) => {
+var getMainCommitPrompt = async (fullGitMojiSpec, context2) => {
   switch (config4.OCO_PROMPT_MODULE) {
     case "@commitlint":
       if (!await commitlintLLMConfigExists()) {
@@ -63826,7 +63820,7 @@ var getMainCommitPrompt = async (fullGitMojiSpec) => {
       ];
     default:
       return [
-        INIT_MAIN_PROMPT2(translation3.localLanguage, fullGitMojiSpec),
+        INIT_MAIN_PROMPT2(translation3.localLanguage, fullGitMojiSpec, context2),
         INIT_DIFF_PROMPT,
         INIT_CONSISTENCY_PROMPT(translation3)
       ];
@@ -63853,8 +63847,8 @@ function mergeDiffs(arr, maxStringLength) {
 var config5 = getConfig();
 var MAX_TOKENS_INPUT = config5.OCO_TOKENS_MAX_INPUT;
 var MAX_TOKENS_OUTPUT = config5.OCO_TOKENS_MAX_OUTPUT;
-var generateCommitMessageChatCompletionPrompt = async (diff, fullGitMojiSpec) => {
-  const INIT_MESSAGES_PROMPT = await getMainCommitPrompt(fullGitMojiSpec);
+var generateCommitMessageChatCompletionPrompt = async (diff, fullGitMojiSpec, context2) => {
+  const INIT_MESSAGES_PROMPT = await getMainCommitPrompt(fullGitMojiSpec, context2);
   const chatContextAsCompletionRequest = [...INIT_MESSAGES_PROMPT];
   chatContextAsCompletionRequest.push({
     role: "user",
@@ -63870,9 +63864,12 @@ var GenerateCommitMessageErrorEnum = ((GenerateCommitMessageErrorEnum2) => {
   return GenerateCommitMessageErrorEnum2;
 })(GenerateCommitMessageErrorEnum || {});
 var ADJUSTMENT_FACTOR = 20;
-var generateCommitMessageByDiff = async (diff, fullGitMojiSpec = false) => {
+var generateCommitMessageByDiff = async (diff, fullGitMojiSpec = false, context2 = "") => {
   try {
-    const INIT_MESSAGES_PROMPT = await getMainCommitPrompt(fullGitMojiSpec);
+    const INIT_MESSAGES_PROMPT = await getMainCommitPrompt(
+      fullGitMojiSpec,
+      context2
+    );
     const INIT_MESSAGES_PROMPT_LENGTH = INIT_MESSAGES_PROMPT.map(
       (msg) => tokenCount(msg.content) + 4
     ).reduce((a3, b3) => a3 + b3, 0);
@@ -63892,7 +63889,8 @@ var generateCommitMessageByDiff = async (diff, fullGitMojiSpec = false) => {
     }
     const messages = await generateCommitMessageChatCompletionPrompt(
       diff,
-      fullGitMojiSpec
+      fullGitMojiSpec,
+      context2
     );
     const engine = getEngine();
     const commitMessage = await engine.generateCommitMessage(messages);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,12 @@ cli(
     commands: [configCommand, hookCommand, commitlintConfigCommand],
     flags: {
       fgm: Boolean,
+      context: {
+        type: String,
+        alias: 'c',
+        description: 'Additional user input context for the commit message',
+        default: ''
+      },
       yes: {
         type: Boolean,
         alias: 'y',
@@ -37,7 +43,7 @@ cli(
     if (await isHookCalled()) {
       prepareCommitMessageHook();
     } else {
-      commit(extraArgs, false, flags.fgm, flags.yes);
+      commit(extraArgs, flags.context, false, flags.fgm, flags.yes);
     }
   },
   extraArgs

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -36,6 +36,16 @@ const checkMessageTemplate = (extraArgs: string[]): string | false => {
   return false;
 };
 
+// remove all args after '--'
+const cleanupContext = (extraArgs: string[]): string[] => {
+  // remove all args after '--'
+  const index = extraArgs.indexOf('--');
+  if (index !== -1) {
+    extraArgs = extraArgs.slice(0, index);
+  }
+  return extraArgs;
+};
+
 interface GenerateCommitMessageFromGitDiffParams {
   diff: string;
   extraArgs: string[];
@@ -97,7 +107,7 @@ ${chalk.grey('——————————————————')}`
         'commit',
         '-m',
         commitMessage,
-        ...extraArgs
+        ...cleanupContext(extraArgs)
       ]);
       committingChangesSpinner.stop(
         `${chalk.green('✔')} Successfully committed`

--- a/src/generateCommitMessageFromGitDiff.ts
+++ b/src/generateCommitMessageFromGitDiff.ts
@@ -11,9 +11,10 @@ const MAX_TOKENS_OUTPUT = config.OCO_TOKENS_MAX_OUTPUT;
 
 const generateCommitMessageChatCompletionPrompt = async (
   diff: string,
-  fullGitMojiSpec: boolean
+  fullGitMojiSpec: boolean,
+  context: string
 ): Promise<Array<OpenAI.Chat.Completions.ChatCompletionMessageParam>> => {
-  const INIT_MESSAGES_PROMPT = await getMainCommitPrompt(fullGitMojiSpec);
+  const INIT_MESSAGES_PROMPT = await getMainCommitPrompt(fullGitMojiSpec, context);
 
   const chatContextAsCompletionRequest = [...INIT_MESSAGES_PROMPT];
 
@@ -36,10 +37,14 @@ const ADJUSTMENT_FACTOR = 20;
 
 export const generateCommitMessageByDiff = async (
   diff: string,
-  fullGitMojiSpec: boolean = false
+  fullGitMojiSpec: boolean = false,
+  context: string = ""
 ): Promise<string> => {
   try {
-    const INIT_MESSAGES_PROMPT = await getMainCommitPrompt(fullGitMojiSpec);
+    const INIT_MESSAGES_PROMPT = await getMainCommitPrompt(
+      fullGitMojiSpec,
+      context
+    );
 
     const INIT_MESSAGES_PROMPT_LENGTH = INIT_MESSAGES_PROMPT.map(
       (msg) => tokenCount(msg.content as string) + 4
@@ -69,7 +74,8 @@ export const generateCommitMessageByDiff = async (
 
     const messages = await generateCommitMessageChatCompletionPrompt(
       diff,
-      fullGitMojiSpec
+      fullGitMojiSpec,
+      context,
     );
 
     const engine = getEngine();

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -111,6 +111,26 @@ const getOneLineCommitInstruction = () =>
     ? 'Craft a concise commit message that encapsulates all changes made, with an emphasis on the primary updates. If the modifications share a common theme or scope, mention it succinctly; otherwise, leave the scope out to maintain focus. The goal is to provide a clear and unified overview of the changes in a one single message, without diverging into a list of commit per file change.'
     : '';
 
+/**
+ * Get the context of the user input
+ * @param extraArgs - The arguments passed to the command line
+ * @example
+ *  $ oco -- This is a context used to generate the commit message
+ * @returns - The context of the user input
+ */
+const userInputCodeContext = () => {
+  const args = process.argv;
+  // Find all arguments after '--'
+  const dashIndex = args.indexOf('--');
+  if (dashIndex !== -1) {
+    const context = args.slice(dashIndex + 1).join(' ');
+    if (context !== '' && context !== ' ') {
+      return `Additional context provided by the user: ${context}\n\nConsider this context when generating the commit message, incorporating relevant information when appropriate.`;
+    }
+  }
+  return '';
+};
+
 const INIT_MAIN_PROMPT = (
   language: string,
   fullGitMojiSpec: boolean
@@ -127,8 +147,9 @@ const INIT_MAIN_PROMPT = (
     const descriptionGuideline = getDescriptionInstruction();
     const oneLineCommitGuideline = getOneLineCommitInstruction();
     const generalGuidelines = `Use the present tense. Lines must not be longer than 74 characters. Use ${language} for the commit message.`;
+    const userInputContext = userInputCodeContext();
 
-    return `${missionStatement}\n${diffInstruction}\n${conventionGuidelines}\n${descriptionGuideline}\n${oneLineCommitGuideline}\n${generalGuidelines}`;
+    return `${missionStatement}\n${diffInstruction}\n${conventionGuidelines}\n${descriptionGuideline}\n${oneLineCommitGuideline}\n${generalGuidelines}\n${userInputContext}`;
   })()
 });
 


### PR DESCRIPTION
# Enhance Context Awareness for Commit Message Generation

OpenCommit now allows you to provide additional context when generating commit messages. This context is incorporated into the prompt given to the AI model, enabling it to create more tailored and relevant commit messages.

## Usage

To provide additional context, use the `--context` flag followed by your context in quotes after the OpenCommit command:

```
oco --context "This commit updates the authentication flow to use JWT tokens"
```

The AI model will consider the provided context when generating the commit message, incorporating relevant information when appropriate.

## Benefits

- **Context-aware commit messages**: By providing additional context, the generated commit messages will be more aligned with the specific changes made, resulting in clearer and more descriptive commit messages.
- **Improved relevance**: The AI model can better understand the intent and purpose behind the changes, leading to commit messages that accurately reflect the modifications.
- **Customization**: You can tailor the commit message generation process by providing context specific to your project or development environment.

This enhancement strengthens OpenCommit's ability to generate meaningful and accurate commit messages, facilitating better commit history management and code collaboration.