### PR TITLE
Feat: Add an option to `Don't push` when there are multiple git remotes

### DIFF
--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -148,26 +148,29 @@ ${chalk.grey('——————————————————')}`
           process.exit(0);
         }
       } else {
+        const skipOption = `Don't push`
         const selectedRemote = (await select({
           message: 'Choose a remote to push to',
-          options: remotes.map((remote) => ({ value: remote, label: remote }))
+          options: [...remotes, skipOption].map((remote) => ({ value: remote, label: remote })),
         })) as string;
 
         if (isCancel(selectedRemote)) process.exit(1);
 
-        const pushSpinner = spinner();
-
-        pushSpinner.start(`Running 'git push ${selectedRemote}'`);
-
-        const { stdout } = await execa('git', ['push', selectedRemote]);
-
-        if (stdout) outro(stdout);
-
-        pushSpinner.stop(
-          `${chalk.green(
-            '✔'
-          )} successfully pushed all commits to ${selectedRemote}`
-        );
+        if (selectedRemote !== skipOption) {
+          const pushSpinner = spinner();
+  
+          pushSpinner.start(`Running 'git push ${selectedRemote}'`);
+  
+          const { stdout } = await execa('git', ['push', selectedRemote]);
+  
+          if (stdout) outro(stdout);
+  
+          pushSpinner.stop(
+            `${chalk.green(
+              '✔'
+            )} successfully pushed all commits to ${selectedRemote}`
+          );
+        }
       }
     } else {
       const regenerateMessage = await confirm({

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -148,7 +148,7 @@ ${chalk.grey('——————————————————')}`
           process.exit(0);
         }
       } else {
-        const skipOption = `Don't push`
+        const skipOption = `don't push`
         const selectedRemote = (await select({
           message: 'Choose a remote to push to',
           options: [...remotes, skipOption].map((remote) => ({ value: remote, label: remote })),


### PR DESCRIPTION
### Description
When you run 'oco' command and commit, you will be asked which remote to push to if there are multiple remotes.
Currently, you have to force quit by Ctrl-C if you don't want to push.
I have improved usability by adding an option to `Don't push`.

### Changes
Added `Don't push` as an option in the git push flow when there are multiple remotes.

**Before:**
![image](https://github.com/user-attachments/assets/ae3303d5-17b8-47bb-8b3a-4f93a36ca36c)

**After:**
![image](https://github.com/user-attachments/assets/cddc4cc0-0835-4a0b-a831-b8f6d0b45e7f)
