### PR TITLE
Fix: Use default configured URL for Flowise engine client requests

### DIFF
--- a/out/cli.cjs
+++ b/out/cli.cjs
@@ -58583,7 +58583,10 @@ var FlowiseEngine = class {
       history: messages.slice(1, -1)
     };
     try {
-      const response = await this.client.post("", payload);
+      const response = await this.client.post(
+        this.client.defaults.url,
+         payload
+        );
       const message = response.data;
       return message?.text;
     } catch (err) {

--- a/out/cli.cjs
+++ b/out/cli.cjs
@@ -58583,10 +58583,7 @@ var FlowiseEngine = class {
       history: messages.slice(1, -1)
     };
     try {
-      const response = await this.client.post(
-        this.client.defaults.url,
-         payload
-        );
+      const response = await this.client.post("", payload);
       const message = response.data;
       return message?.text;
     } catch (err) {

--- a/src/engine/flowise.ts
+++ b/src/engine/flowise.ts
@@ -34,7 +34,11 @@ export class FlowiseEngine implements AiEngine {
       history: messages.slice(1, -1)
     };
     try {
-      const response = await this.client.post('', payload);
+      const response = await this.client.post(
+        this.client.getUri(this.config),
+        payload
+      );
+      
       const message = response.data;
       return message?.text;
     } catch (err: any) {


### PR DESCRIPTION
## 🛠️ Fixing the Way to Flowise 🛤️
This PR ensures we're no longer shooting blind when sending requests to the Flowise engine. Instead of relying on an empty string ("") for the URL, we're now using the default configured URL already baked into the client (this.client.defaults.url). Why reinvent the wheel, right? 🚗

### What Changed?

- Updated this.client.post("", payload)
- To the much smarter this.client.post(this.client.defaults.url, payload)

### Why?
Because "empty string engineering" is not exactly best practice (or fun during debugging). Now requests follow the default road map as intended! 🎯
