### PR TITLE
Enhance OllamaEngine to remove <think> blocks in response content

### DIFF
--- a/src/engine/ollama.ts
+++ b/src/engine/ollama.ts
@@ -33,9 +33,14 @@ export class OllamaEngine implements AiEngine {
         params
       );
 
-      const message = response.data.message;
+      const { message } = response.data;
+      let content = message?.content;
 
-      return message?.content;
+      if (content && content.includes('<think>')) {
+        return content.replace(/<think>[\s\S]*?<\/think>/g, '').trim();
+      }
+
+      return content;
     } catch (err: any) {
       const message = err.response?.data?.error ?? err.message;
       throw new Error(`Ollama provider error: ${message}`);


### PR DESCRIPTION
Hello,

When utilizing the DeepSeek model via Ollama, responses generated by the reasoning model include reflective content encapsulated within <think> and </think> tags. 
This additional information is intended for internal reasoning processes and is not suitable for commit messages. To ensure that only the conventional commit message is retained, it is necessary to remove any content enclosed within these tags.

I did this only for ollama, maybe it would be better to add an option to remove this kind of tag globally.

