### PR TITLE
feat(commitlint): add additional search path for @commitlint

### DIFF
--- a/src/modules/commitlint/pwd-commitlint.ts
+++ b/src/modules/commitlint/pwd-commitlint.ts
@@ -4,7 +4,8 @@ import path from 'path';
 const findModulePath = (moduleName: string) => {
   const searchPaths = [
     path.join('node_modules', moduleName),
-    path.join('node_modules', '.pnpm')
+    path.join('node_modules', '.pnpm'),
+    path.resolve(__dirname, '../..')
   ];
 
   for (const basePath of searchPaths) {


### PR DESCRIPTION
This change allows opencommit to locate commitlint installed globally (with opencommit), which is useful for project that does not use node.js environment or dose not install opencommit and @commitlint locally.