### PR TITLE
fix: config default settings

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -155,8 +155,8 @@ const getDefaultModel = (provider: string | undefined): string => {
 };
 
 export enum DEFAULT_TOKEN_LIMITS {
-  DEFAULT_MAX_TOKENS_INPUT = 40960,
-  DEFAULT_MAX_TOKENS_OUTPUT = 4096
+  DEFAULT_MAX_TOKENS_INPUT = 4096,
+  DEFAULT_MAX_TOKENS_OUTPUT = 500
 }
 
 const validateConfig = (


### PR DESCRIPTION
The defaults in the README.md do not match the config file, tweaked it to match the configuration described in the README.md (the it should be the opposite, either way it must match)