### PR TITLE
Add OCO_API_CUSTOM_HEADERS

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Create a `.env` file and add OpenCommit config variables there like this:
 OCO_AI_PROVIDER=<openai (default), anthropic, azure, ollama, gemini, flowise, deepseek>
 OCO_API_KEY=<your OpenAI API token> // or other LLM provider API token
 OCO_API_URL=<may be used to set proxy path to OpenAI api>
+OCO_API_CUSTOM_HEADERS=<JSON string of custom HTTP headers to include in API requests>
 OCO_TOKENS_MAX_INPUT=<max model token limit (default: 4096)>
 OCO_TOKENS_MAX_OUTPUT=<max response tokens (default: 500)>
 OCO_DESCRIPTION=<postface a message with ~3 sentences description of the changes>

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -25,6 +25,7 @@ export enum CONFIG_KEYS {
   OCO_ONE_LINE_COMMIT = 'OCO_ONE_LINE_COMMIT',
   OCO_TEST_MOCK_TYPE = 'OCO_TEST_MOCK_TYPE',
   OCO_API_URL = 'OCO_API_URL',
+  OCO_API_CUSTOM_HEADERS = 'OCO_API_CUSTOM_HEADERS',
   OCO_OMIT_SCOPE = 'OCO_OMIT_SCOPE',
   OCO_GITPUSH = 'OCO_GITPUSH' // todo: deprecate
 }
@@ -204,6 +205,22 @@ export const configValidators = {
     return value;
   },
 
+  [CONFIG_KEYS.OCO_API_CUSTOM_HEADERS](value) {
+    try {
+      // Custom headers must be a valid JSON string
+      if (typeof value === 'string') {
+        JSON.parse(value);
+      }
+      return value;
+    } catch (error) {
+      validateConfig(
+        CONFIG_KEYS.OCO_API_CUSTOM_HEADERS,
+        false,
+        'Must be a valid JSON string of headers'
+      );
+    }
+  },
+
   [CONFIG_KEYS.OCO_TOKENS_MAX_INPUT](value: any) {
     value = parseInt(value);
     validateConfig(
@@ -380,6 +397,7 @@ export type ConfigType = {
   [CONFIG_KEYS.OCO_TOKENS_MAX_INPUT]: number;
   [CONFIG_KEYS.OCO_TOKENS_MAX_OUTPUT]: number;
   [CONFIG_KEYS.OCO_API_URL]?: string;
+  [CONFIG_KEYS.OCO_API_CUSTOM_HEADERS]?: string;
   [CONFIG_KEYS.OCO_DESCRIPTION]: boolean;
   [CONFIG_KEYS.OCO_EMOJI]: boolean;
   [CONFIG_KEYS.OCO_WHY]: boolean;
@@ -462,6 +480,7 @@ const getEnvConfig = (envPath: string) => {
     OCO_MODEL: process.env.OCO_MODEL,
     OCO_API_URL: process.env.OCO_API_URL,
     OCO_API_KEY: process.env.OCO_API_KEY,
+    OCO_API_CUSTOM_HEADERS: process.env.OCO_API_CUSTOM_HEADERS,
     OCO_AI_PROVIDER: process.env.OCO_AI_PROVIDER as OCO_AI_PROVIDER_ENUM,
 
     OCO_TOKENS_MAX_INPUT: parseConfigVarValue(process.env.OCO_TOKENS_MAX_INPUT),

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -11,6 +11,7 @@ export interface AiEngineConfig {
   maxTokensOutput: number;
   maxTokensInput: number;
   baseURL?: string;
+  customHeaders?: Record<string, string>;
 }
 
 type Client =

--- a/src/engine/ollama.ts
+++ b/src/engine/ollama.ts
@@ -11,11 +11,18 @@ export class OllamaEngine implements AiEngine {
 
   constructor(config) {
     this.config = config;
+    
+    // Combine base headers with custom headers
+    const headers = { 
+      'Content-Type': 'application/json',
+      ...config.customHeaders 
+    };
+    
     this.client = axios.create({
       url: config.baseURL
         ? `${config.baseURL}/${config.apiKey}`
         : 'http://localhost:11434/api/chat',
-      headers: { 'Content-Type': 'application/json' }
+      headers
     });
   }
 

--- a/src/engine/openAi.ts
+++ b/src/engine/openAi.ts
@@ -14,21 +14,17 @@ export class OpenAiEngine implements AiEngine {
   constructor(config: OpenAiConfig) {
     this.config = config;
 
-    // Configuration options for the OpenAI client
-    const clientOptions: any = {
+    const clientOptions: OpenAI.ClientOptions = {
       apiKey: config.apiKey
     };
     
-    // Add baseURL if present
     if (config.baseURL) {
       clientOptions.baseURL = config.baseURL;
     }
     
-    // Add custom headers if present
     if (config.customHeaders) {
       try {
         let headers = config.customHeaders;
-        // If the headers are a string, try to parse them as JSON
         if (typeof config.customHeaders === 'string') {
           headers = JSON.parse(config.customHeaders);
         }
@@ -37,7 +33,6 @@ export class OpenAiEngine implements AiEngine {
           clientOptions.defaultHeaders = headers;
         }
       } catch (error) {
-        // Silently ignore parsing errors
       }
     }
     

--- a/src/engine/openAi.ts
+++ b/src/engine/openAi.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { OpenAI } from 'openai';
 import { GenerateCommitMessageErrorEnum } from '../generateCommitMessageFromGitDiff';
+import { parseCustomHeaders } from '../utils/engine';
 import { removeContentTags } from '../utils/removeContentTags';
 import { tokenCount } from '../utils/tokenCount';
 import { AiEngine, AiEngineConfig } from './Engine';
@@ -23,16 +24,9 @@ export class OpenAiEngine implements AiEngine {
     }
     
     if (config.customHeaders) {
-      try {
-        let headers = config.customHeaders;
-        if (typeof config.customHeaders === 'string') {
-          headers = JSON.parse(config.customHeaders);
-        }
-        
-        if (headers && typeof headers === 'object' && Object.keys(headers).length > 0) {
-          clientOptions.defaultHeaders = headers;
-        }
-      } catch (error) {
+      const headers = parseCustomHeaders(config.customHeaders);
+      if (Object.keys(headers).length > 0) {
+        clientOptions.defaultHeaders = headers;
       }
     }
     

--- a/src/utils/engine.ts
+++ b/src/utils/engine.ts
@@ -12,7 +12,7 @@ import { GroqEngine } from '../engine/groq';
 import { MLXEngine } from '../engine/mlx';
 import { DeepseekEngine } from '../engine/deepseek';
 
-function parseCustomHeaders(headers: any): Record<string, string> {
+export function parseCustomHeaders(headers: any): Record<string, string> {
   let parsedHeaders = {};
   
   if (!headers) {

--- a/src/utils/engine.ts
+++ b/src/utils/engine.ts
@@ -12,25 +12,31 @@ import { GroqEngine } from '../engine/groq';
 import { MLXEngine } from '../engine/mlx';
 import { DeepseekEngine } from '../engine/deepseek';
 
+function parseCustomHeaders(headers: any): Record<string, string> {
+  let parsedHeaders = {};
+  
+  if (!headers) {
+    return parsedHeaders;
+  }
+  
+  try {
+    if (typeof headers === 'object' && !Array.isArray(headers)) {
+      parsedHeaders = headers;
+    } else {
+      parsedHeaders = JSON.parse(headers);
+    }
+  } catch (error) {
+    console.warn('Invalid OCO_API_CUSTOM_HEADERS format, ignoring custom headers');
+  }
+  
+  return parsedHeaders;
+}
+
 export function getEngine(): AiEngine {
   const config = getConfig();
   const provider = config.OCO_AI_PROVIDER;
 
-  // Parse custom headers if provided
-  let customHeaders = {};
-  if (config.OCO_API_CUSTOM_HEADERS) {
-    try {
-      // If it's already an object, no need to parse it
-      if (typeof config.OCO_API_CUSTOM_HEADERS === 'object' && !Array.isArray(config.OCO_API_CUSTOM_HEADERS)) {
-        customHeaders = config.OCO_API_CUSTOM_HEADERS;
-      } else {
-        // Try to parse as JSON
-        customHeaders = JSON.parse(config.OCO_API_CUSTOM_HEADERS);
-      }
-    } catch (error) {
-      console.warn('Invalid OCO_API_CUSTOM_HEADERS format, ignoring custom headers');
-    }
-  }
+  const customHeaders = parseCustomHeaders(config.OCO_API_CUSTOM_HEADERS);
 
   const DEFAULT_CONFIG = {
     model: config.OCO_MODEL!,
@@ -38,7 +44,7 @@ export function getEngine(): AiEngine {
     maxTokensInput: config.OCO_TOKENS_MAX_INPUT!,
     baseURL: config.OCO_API_URL!,
     apiKey: config.OCO_API_KEY!,
-    customHeaders // Add custom headers to the configuration
+    customHeaders
   };
 
   switch (provider) {

--- a/src/utils/engine.ts
+++ b/src/utils/engine.ts
@@ -16,12 +16,29 @@ export function getEngine(): AiEngine {
   const config = getConfig();
   const provider = config.OCO_AI_PROVIDER;
 
+  // Parse custom headers if provided
+  let customHeaders = {};
+  if (config.OCO_API_CUSTOM_HEADERS) {
+    try {
+      // If it's already an object, no need to parse it
+      if (typeof config.OCO_API_CUSTOM_HEADERS === 'object' && !Array.isArray(config.OCO_API_CUSTOM_HEADERS)) {
+        customHeaders = config.OCO_API_CUSTOM_HEADERS;
+      } else {
+        // Try to parse as JSON
+        customHeaders = JSON.parse(config.OCO_API_CUSTOM_HEADERS);
+      }
+    } catch (error) {
+      console.warn('Invalid OCO_API_CUSTOM_HEADERS format, ignoring custom headers');
+    }
+  }
+
   const DEFAULT_CONFIG = {
     model: config.OCO_MODEL!,
     maxTokensOutput: config.OCO_TOKENS_MAX_OUTPUT!,
     maxTokensInput: config.OCO_TOKENS_MAX_INPUT!,
     baseURL: config.OCO_API_URL!,
-    apiKey: config.OCO_API_KEY!
+    apiKey: config.OCO_API_KEY!,
+    customHeaders // Add custom headers to the configuration
   };
 
   switch (provider) {

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -122,6 +122,30 @@ describe('config', () => {
       expect(config.OCO_ONE_LINE_COMMIT).toEqual(false);
       expect(config.OCO_OMIT_SCOPE).toEqual(true);
     });
+    
+    it('should handle custom HTTP headers correctly', async () => {
+      globalConfigFile = await generateConfig('.opencommit', {
+        OCO_API_CUSTOM_HEADERS: '{"X-Global-Header": "global-value"}'
+      });
+
+      envConfigFile = await generateConfig('.env', {
+        OCO_API_CUSTOM_HEADERS: '{"Authorization": "Bearer token123", "X-Custom-Header": "test-value"}'
+      });
+
+      const config = getConfig({
+        globalPath: globalConfigFile.filePath,
+        envPath: envConfigFile.filePath
+      });
+
+      expect(config).not.toEqual(null);
+      expect(config.OCO_API_CUSTOM_HEADERS).toEqual('{"Authorization": "Bearer token123", "X-Custom-Header": "test-value"}');
+      
+      // Verify that the JSON can be parsed correctly
+      const parsedHeaders = JSON.parse(config.OCO_API_CUSTOM_HEADERS);
+      expect(parsedHeaders).toHaveProperty('Authorization', 'Bearer token123');
+      expect(parsedHeaders).toHaveProperty('X-Custom-Header', 'test-value');
+      expect(parsedHeaders).not.toHaveProperty('X-Global-Header');
+    });
 
     it('should handle empty local config correctly', async () => {
       globalConfigFile = await generateConfig('.opencommit', {

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -138,10 +138,10 @@ describe('config', () => {
       });
 
       expect(config).not.toEqual(null);
-      expect(config.OCO_API_CUSTOM_HEADERS).toEqual('{"Authorization": "Bearer token123", "X-Custom-Header": "test-value"}');
+      expect(config.OCO_API_CUSTOM_HEADERS).toEqual({"Authorization": "Bearer token123", "X-Custom-Header": "test-value"});
       
-      // Verify that the JSON can be parsed correctly
-      const parsedHeaders = JSON.parse(config.OCO_API_CUSTOM_HEADERS);
+      // No need to parse JSON again since it's already an object
+      const parsedHeaders = config.OCO_API_CUSTOM_HEADERS;
       expect(parsedHeaders).toHaveProperty('Authorization', 'Bearer token123');
       expect(parsedHeaders).toHaveProperty('X-Custom-Header', 'test-value');
       expect(parsedHeaders).not.toHaveProperty('X-Global-Header');


### PR DESCRIPTION
### Description

This pull request implements the feature described in #466 by adding support for custom HTTP headers in API requests via the new `OCO_API_CUSTOM_HEADERS` configuration option.

#### Main changes

- Introduces the `OCO_API_CUSTOM_HEADERS` environment/config variable.
- Allows users to set custom HTTP headers (as a JSON object) for all API requests, supporting use cases like custom authentication, corporate proxy headers, and API gateway requirements.

#### Example usage

```sh
oco config set OCO_API_CUSTOM_HEADERS='{"Authorization": "Basic dXNlcm5hbWU6cGFzc3dvcmQ="}'
oco config set OCO_API_CUSTOM_HEADERS='{"X-API-Version": "2", "X-Custom-Header": "value"}'
```

#### Additional context

Close #466