### PR TITLE
feat(cli.ts): enhance fgm flag to include description and default value for better usability

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,11 @@ cli(
     name: 'opencommit',
     commands: [configCommand, hookCommand, commitlintConfigCommand],
     flags: {
-      fgm: Boolean,
+      fgm: {
+        type: Boolean,
+        description: 'Use full GitMoji specification',
+        default: false
+      },
       context: {
         type: String,
         alias: 'c',


### PR DESCRIPTION
## Summary

Thank you for such a great tool😀

I noticed that the `--fgm` option in the `oco` command help output does not have a description:

The motivation of this pull request is to improve the clarity of the help message by adding a description for the `--fgm` flag.

## Before

```sh
$ oco -h
opencommit v3.2.7

Auto-generate impressive commits in 1 second. Killing lame commits with AI 🤯🔫

Usage:
  opencommit [flags...]
  opencommit <command>

Commands:
  config
  hook
  commitlint

Flags:
  -c, --context <string>        Additional user input context for the commit message
      --fgm
  -h, --help                    Show help
      --version                 Show version
  -y, --yes                     Skip commit confirmation prompt
  ```
  
  ## After
  
  ```sh
  $ oco -h  
opencommit v3.2.7

Auto-generate impressive commits in 1 second. Killing lame commits with AI 🤯🔫

Usage:
  opencommit [flags...]
  opencommit <command>

Commands:
  config                                                                                                                                                                                                  
  hook                                                                                                                                                                                                    
  commitlint                                                                                                                                                                                              

Flags:
  -c, --context <string>        Additional user input context for the commit message                                                                                                                      
      --fgm                     Use full GitMoji specification                                                                                                                                            
  -h, --help                    Show help                                                                                                                                                                 
      --version                 Show version                                                                                                                                                              
  -y, --yes                     Skip commit confirmation prompt    
  ```

Could you please review? Thanks a lot 👍