### PR TITLE
feat(config): add 'describe' mode to config command for detailed parameter info

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ OCO_TOKENS_MAX_INPUT=<max model token limit (default: 4096)>
 OCO_TOKENS_MAX_OUTPUT=<max response tokens (default: 500)>
 OCO_DESCRIPTION=<postface a message with ~3 sentences description of the changes>
 OCO_EMOJI=<boolean, add GitMoji>
-OCO_MODEL=<either 'gpt-4o', 'gpt-4', 'gpt-4-turbo', 'gpt-3.5-turbo' (default), 'gpt-3.5-turbo-0125', 'gpt-4-1106-preview', 'gpt-4-turbo-preview' or 'gpt-4-0125-preview' or any Anthropic or Ollama model or any string basically, but it should be a valid model name>
+OCO_MODEL=<either 'gpt-4o-mini' (default), 'gpt-4o', 'gpt-4', 'gpt-4-turbo', 'gpt-3.5-turbo', 'gpt-3.5-turbo-0125', 'gpt-4-1106-preview', 'gpt-4-turbo-preview' or 'gpt-4-0125-preview' or any Anthropic or Ollama model or any string basically, but it should be a valid model name>
 OCO_LANGUAGE=<locale, scroll to the bottom to see options>
 OCO_MESSAGE_TEMPLATE_PLACEHOLDER=<message template placeholder, default: '$msg'>
 OCO_PROMPT_MODULE=<either conventional-commit or @commitlint, default: conventional-commit>
@@ -131,6 +131,18 @@ Simply set any of the variables above like this:
 
 ```sh
 oco config set OCO_MODEL=gpt-4o-mini
+```
+
+To see all available configuration parameters and their accepted values:
+
+```sh
+oco config describe
+```
+
+To see details for a specific parameter:
+
+```sh
+oco config describe OCO_MODEL
 ```
 
 Configure [GitMoji](https://gitmoji.dev/) to preface a message.


### PR DESCRIPTION
This commit adds a new 'describe' mode to the config command, allowing users to get detailed information about configuration parameters. It includes:

1. New CONFIG_MODES.describe enum value
2. Functions to generate and print help messages for config parameters
3. Updated configCommand to handle the new 'describe' mode
4. README updates to document the new 'describe' functionality

The `describe` mode can be used in two ways:

1. To print help for all available config parameters: ``` oco config describe ```

2. To print help for specific config parameters: ``` oco config describe OCO_MODEL OCO_API_KEY ```

Additionally, the commit fixes the error handling for the `get` and `set` modes, ensuring that an error is thrown if no config keys are provided.

These changes improve the usability and discoverability of the configuration system, making it easier for users to understand and manage their opencommit settings.

See #470 

## Example Usage
```
oco config describe
┌  COMMAND: config describe 
Available config parameters:

OCO_AI_PROVIDER:
  Description: The AI provider to use
  Default: openai

OCO_API_KEY:
  Description: API key for the selected provider

OCO_API_URL:
  Description: Custom API URL - may be used to set proxy path to OpenAI API

OCO_DESCRIPTION:
  Description: Postface a message with ~3 sentences description of the changes
  Default: false
...
...
... 
```


```
oco config describe OCO_AI_PROVIDER
┌  COMMAND: config describe OCO_AI_PROVIDER

OCO_AI_PROVIDER:
  Description: The AI provider to use
  Default: openai
  Accepted values:
    - ollama
    - openai
    - anthropic
    - gemini
    - azure
    - test
    - flowise
    - groq
    - mistral
    - mlx
    - deepseek