### PR TITLE
fix(migrations): skip unhandled AI providers during migration execution

### DIFF
--- a/src/migrations/_run.ts
+++ b/src/migrations/_run.ts
@@ -36,6 +36,19 @@ export const runMigrations = async () => {
   const config = getConfig();
   if (config.OCO_AI_PROVIDER === OCO_AI_PROVIDER_ENUM.TEST) return;
 
+  // skip unhandled providers in migration00
+  if (
+    [
+      OCO_AI_PROVIDER_ENUM.DEEPSEEK,
+      OCO_AI_PROVIDER_ENUM.GROQ,
+      OCO_AI_PROVIDER_ENUM.MISTRAL,
+      OCO_AI_PROVIDER_ENUM.MLX,
+      OCO_AI_PROVIDER_ENUM.OPENROUTER,
+    ].includes(config.OCO_AI_PROVIDER)
+  ) {
+    return;
+  }
+
   const completedMigrations = getCompletedMigrations();
 
   let isMigrated = false;


### PR DESCRIPTION
The changes:
1. Expanded the skip condition to include additional AI providers (DEEPSEEK, GROQ, MISTRAL, MLX, OPENROUTER) beyond just TEST
2. Maintained existing TEST provider skip behavior
3. Added explicit comment explaining the skip logic

The why:
Prevents migration execution for unsupported AI providers to avoid potential runtime errors or data inconsistencies, ensuring migrations only run for properly handled configurations.

Fix #468 