### PR TITLE
feat(prepare-commit-msg-hook): enhance commit message formatting with a divider and instructions for better user guidance

### DIFF
--- a/src/commands/prepare-commit-msg-hook.ts
+++ b/src/commands/prepare-commit-msg-hook.ts
@@ -56,9 +56,11 @@ export const prepareCommitMessageHook = async (
 
     const fileContent = await fs.readFile(messageFilePath);
 
+    const divider = '# ---------- [OpenCommit] ---------- #';
+
     await fs.writeFile(
       messageFilePath,
-      commitMessage + '\n' + fileContent.toString()
+      `# ${commitMessage}\n\n${divider}\n# Remove the # above to use this generated commit message.\n# To cancel the commit, just close this window without making any changes.\n\n${fileContent.toString()}`
     );
   } catch (error) {
     outro(`${chalk.red('✖')} ${error}`);


### PR DESCRIPTION
According to the discussion at https://github.com/di-sukharev/opencommit/issues/490, modify the `git commit` template during the hook to the default comment stats to align with general `git commit` practices.

![終端機 - phantasweng — owlting -l — owlting — ssh -t ubuntu@192 168 70 92 tmux new -A -s server — 237×60_2025_07_01 at 14 09 35](https://github.com/user-attachments/assets/eb2b8d11-435c-48f8-87f0-48214453a7e2)

![終端機 - phantasweng — owlting -l — owlting — ssh -t ubuntu@192 168 70 92 tmux new -A -s server — 237×60_2025_07_01 at 14 02 27](https://github.com/user-attachments/assets/00d69822-9cb8-440d-ac0e-075e9cca0793)