### PR TITLE
Fix git commands when executed from subdirectories

### DIFF
--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -1,7 +1,7 @@
 import { execa } from 'execa';
 import { readFileSync } from 'fs';
 import ignore, { Ignore } from 'ignore';
-
+import { join } from 'path';
 import { outro, spinner } from '@clack/prompts';
 
 export const assertGitRepo = async () => {
@@ -16,41 +16,44 @@ export const assertGitRepo = async () => {
 //   (file) => `:(exclude)${file}`
 // );
 
-export const getOpenCommitIgnore = (): Ignore => {
+export const getOpenCommitIgnore = async (): Promise<Ignore> => {
+  const gitDir = await getGitDir();
+
   const ig = ignore();
 
   try {
-    ig.add(readFileSync('.opencommitignore').toString().split('\n'));
+    ig.add(
+      readFileSync(join(gitDir, '.opencommitignore')).toString().split('\n')
+    );
   } catch (e) {}
 
   return ig;
 };
 
 export const getCoreHooksPath = async (): Promise<string> => {
-  const { stdout } = await execa('git', ['config', 'core.hooksPath']);
+  const gitDir = await getGitDir();
+
+  const { stdout } = await execa('git', ['config', 'core.hooksPath'], {
+    cwd: gitDir
+  });
 
   return stdout;
 };
 
 export const getStagedFiles = async (): Promise<string[]> => {
-  const { stdout: gitDir } = await execa('git', [
-    'rev-parse',
-    '--show-toplevel'
-  ]);
+  const gitDir = await getGitDir();
 
-  const { stdout: files } = await execa('git', [
-    'diff',
-    '--name-only',
-    '--cached',
-    '--relative',
-    gitDir
-  ]);
+  const { stdout: files } = await execa(
+    'git',
+    ['diff', '--name-only', '--cached', '--relative'],
+    { cwd: gitDir }
+  );
 
   if (!files) return [];
 
   const filesList = files.split('\n');
 
-  const ig = getOpenCommitIgnore();
+  const ig = await getOpenCommitIgnore();
   const allowedFiles = filesList.filter((file) => !ig.ignores(file));
 
   if (!allowedFiles) return [];
@@ -59,12 +62,17 @@ export const getStagedFiles = async (): Promise<string[]> => {
 };
 
 export const getChangedFiles = async (): Promise<string[]> => {
-  const { stdout: modified } = await execa('git', ['ls-files', '--modified']);
-  const { stdout: others } = await execa('git', [
-    'ls-files',
-    '--others',
-    '--exclude-standard'
-  ]);
+  const gitDir = await getGitDir();
+
+  const { stdout: modified } = await execa('git', ['ls-files', '--modified'], {
+    cwd: gitDir
+  });
+
+  const { stdout: others } = await execa(
+    'git',
+    ['ls-files', '--others', '--exclude-standard'],
+    { cwd: gitDir }
+  );
 
   const files = [...modified.split('\n'), ...others.split('\n')].filter(
     (file) => !!file
@@ -74,16 +82,20 @@ export const getChangedFiles = async (): Promise<string[]> => {
 };
 
 export const gitAdd = async ({ files }: { files: string[] }) => {
+  const gitDir = await getGitDir();
+
   const gitAddSpinner = spinner();
 
   gitAddSpinner.start('Adding files to commit');
 
-  await execa('git', ['add', ...files]);
+  await execa('git', ['add', ...files], { cwd: gitDir });
 
   gitAddSpinner.stop(`Staged ${files.length} files`);
 };
 
 export const getDiff = async ({ files }: { files: string[] }) => {
+  const gitDir = await getGitDir();
+
   const lockFiles = files.filter(
     (file) =>
       file.includes('.lock') ||
@@ -108,12 +120,20 @@ export const getDiff = async ({ files }: { files: string[] }) => {
     (file) => !file.includes('.lock') && !file.includes('-lock.')
   );
 
-  const { stdout: diff } = await execa('git', [
-    'diff',
-    '--staged',
-    '--',
-    ...filesWithoutLocks
-  ]);
+  const { stdout: diff } = await execa(
+    'git',
+    ['diff', '--staged', '--', ...filesWithoutLocks],
+    { cwd: gitDir }
+  );
 
   return diff;
+};
+
+export const getGitDir = async (): Promise<string> => {
+  const { stdout: gitDir } = await execa('git', [
+    'rev-parse',
+    '--show-toplevel'
+  ]);
+
+  return gitDir;
 };


### PR DESCRIPTION
## Fix git commands when executed from subdirectories

### Problem
When opencommit is run from a subdirectory within a git repository, git commands may fail or return incorrect results because they execute relative to the current working directory instead of the git repository root.

### Solution
This PR ensures all git commands are executed from the git repository root by setting the `cwd` option to the result of `getGitDir()` for all `execa('git', ...)` calls.

### Changes Made
- Added `cwd: gitDir` option to all git command executions in `src/utils/git.ts`
- Removed redundant `gitDir` parameter from `git diff --relative` command since we're now running from the correct directory

### Modified Functions
- `getCoreHooksPath()` - Now executes from git root
- `getStagedFiles()` - Now executes from git root and removes redundant `--relative` path
- `getChangedFiles()` - Now executes both git commands from git root  
- `gitAdd()` - Now executes from git root
- `getDiff()` - Now executes from git root

### Testing
This change ensures consistent behavior regardless of which subdirectory opencommit is executed from within a git repository.

Fixes https://github.com/di-sukharev/opencommit/issues/256