### PR TITLE
Fix TypeScript build error and add missing confirm import (regression from #491)

### DIFF
--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -1,5 +1,6 @@
 import {
   text,
+  confirm,
   intro,
   isCancel,
   multiselect,
@@ -99,10 +100,12 @@ ${chalk.grey('——————————————————')}`
     if (isCancel(userAction)) process.exit(1);
 
     if (userAction === 'Edit') {
-      commitMessage = await text({
+      const textResponse = await text({
         message: 'Please edit the commit message: (press Enter to continue)',
         initialValue: commitMessage
       });
+
+      commitMessage = textResponse.toString();
     }
 
     if (userAction === 'Yes' || userAction === 'Edit') {


### PR DESCRIPTION
This PR resolves a TypeScript error in `commit.ts` caused by a missing `confirm` import and incorrect usage of the `text()` prompt. Specifically:
- Adds the missing `confirm` import from the prompt toolkit
- Corrects usage of `text()` by storing the result in a `textResponse` variable and converting it to a string before assigning it to `commitMessage`

These changes fix the build error introduced in #491 and restore proper interactive behavior during the commit flow.

<img width="587" height="262" alt="Screenshot 2568-07-23 at 16 19 58" src="https://github.com/user-attachments/assets/7de83e9a-2697-4b96-865a-301e186f0474" />