### PR TITLE
feat(config): Add options to skip commit and push prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ This flag allows users to automatically commit the changes without having to man
 oco --yes
 ```
 
+You can also set this behavior permanently through configuration:
+
+```
+oco config set OCO_SKIP_COMMIT_CONFIRM=true
+```
+
 ## Configuration
 
 ### Local per repo configuration
@@ -119,6 +125,7 @@ OCO_LANGUAGE=<locale, scroll to the bottom to see options>
 OCO_MESSAGE_TEMPLATE_PLACEHOLDER=<message template placeholder, default: '$msg'>
 OCO_PROMPT_MODULE=<either conventional-commit or @commitlint, default: conventional-commit>
 OCO_ONE_LINE_COMMIT=<one line commit message, default: false>
+OCO_SKIP_COMMIT_CONFIRM=<skip commit confirmation prompt, default: false>
 ```
 
 Global configs are same as local configs, but they are stored in the global `~/.opencommit` config file and set with `oco config set` command, e.g. `oco config set OCO_MODEL=gpt-4o`.

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -86,7 +86,7 @@ ${commitMessage}
 ${chalk.grey('——————————————————')}`
     );
 
-    const userAction = skipCommitConfirmation
+    const userAction = skipCommitConfirmation || config.OCO_SKIP_COMMIT_CONFIRM
       ? 'Yes'
       : await select({
           message: 'Confirm the commit message?',

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -28,7 +28,8 @@ export enum CONFIG_KEYS {
   OCO_API_CUSTOM_HEADERS = 'OCO_API_CUSTOM_HEADERS',
   OCO_OMIT_SCOPE = 'OCO_OMIT_SCOPE',
   OCO_GITPUSH = 'OCO_GITPUSH', // todo: deprecate
-  OCO_HOOK_AUTO_UNCOMMENT = 'OCO_HOOK_AUTO_UNCOMMENT'
+  OCO_HOOK_AUTO_UNCOMMENT = 'OCO_HOOK_AUTO_UNCOMMENT',
+  OCO_SKIP_COMMIT_CONFIRM = 'OCO_SKIP_COMMIT_CONFIRM'
 }
 
 export enum CONFIG_MODES {
@@ -827,6 +828,16 @@ export const configValidators = {
       typeof value === 'boolean',
       'Must be true or false'
     );
+    return value;
+  },
+
+  [CONFIG_KEYS.OCO_SKIP_COMMIT_CONFIRM](value: any) {
+    validateConfig(
+      CONFIG_KEYS.OCO_SKIP_COMMIT_CONFIRM,
+      typeof value === 'boolean',
+      'Must be true or false'
+    );
+    return value;
   }
 };
 
@@ -865,6 +876,7 @@ export type ConfigType = {
   [CONFIG_KEYS.OCO_OMIT_SCOPE]: boolean;
   [CONFIG_KEYS.OCO_TEST_MOCK_TYPE]: string;
   [CONFIG_KEYS.OCO_HOOK_AUTO_UNCOMMENT]: boolean;
+  [CONFIG_KEYS.OCO_SKIP_COMMIT_CONFIRM]: boolean;
 };
 
 export const defaultConfigPath = pathJoin(homedir(), '.opencommit');
@@ -913,7 +925,8 @@ export const DEFAULT_CONFIG = {
   OCO_WHY: false,
   OCO_OMIT_SCOPE: false,
   OCO_GITPUSH: true, // todo: deprecate
-  OCO_HOOK_AUTO_UNCOMMENT: false
+  OCO_HOOK_AUTO_UNCOMMENT: false,
+  OCO_SKIP_COMMIT_CONFIRM: false
 };
 
 const initGlobalConfig = (configPath: string = defaultConfigPath) => {
@@ -954,7 +967,8 @@ const getEnvConfig = (envPath: string) => {
     OCO_TEST_MOCK_TYPE: process.env.OCO_TEST_MOCK_TYPE,
     OCO_OMIT_SCOPE: parseConfigVarValue(process.env.OCO_OMIT_SCOPE),
 
-    OCO_GITPUSH: parseConfigVarValue(process.env.OCO_GITPUSH) // todo: deprecate
+    OCO_GITPUSH: parseConfigVarValue(process.env.OCO_GITPUSH), // todo: deprecate
+    OCO_SKIP_COMMIT_CONFIRM: parseConfigVarValue(process.env.OCO_SKIP_COMMIT_CONFIRM)
   };
 };
 
@@ -1168,6 +1182,11 @@ function getConfigKeyDetails(key) {
     case CONFIG_KEYS.OCO_HOOK_AUTO_UNCOMMENT:
       return {
         description: 'Automatically uncomment the commit message in the hook',
+        values: ['true', 'false']
+      };
+    case CONFIG_KEYS.OCO_SKIP_COMMIT_CONFIRM:
+      return {
+        description: 'Skip the commit message confirmation prompt and auto-commit with generated message',
         values: ['true', 'false']
       };
     default:


### PR DESCRIPTION
This pull request introduces one new configuration options to streamline the commit workflow by skipping unnecessary confirmation steps.

I've been using these changes locally and they have significantly improved my workflow, allowing for faster commits with readable messages without the interruption of prompts. I believe this will be a valuable addition for many users who prefer a more automated process.

#### **Changes:**

*   **`OCO_SKIP_COMMIT_CONFIRM`**: When set to `true`, this option skips the commit message confirmation prompt and automatically commits with the generated message. This is useful for users who trust the generated messages and want to speed up their workflow.


These options can be configured via environment variables or the `opencommit` config file.

#### **Local Usage Log:**

Here's an example of the streamlined workflow in action from my local environment:

```
./out/cli.cjs
┌  open-commit
│
◇  2 staged files:
  src/commands/commit.ts
  src/commands/config.ts
│
◇  📝 Commit message generated
│
└  Generated commit message:
——————————————————
feat(config): add OCO_SKIP_COMMIT_CONFIRM to skip confirmation prompt
feat(config): add OCO_SKIP_PUSH_PROMPT to skip push prompt
refactor(commit): use config.OCO_SKIP_COMMIT_CONFIRM instead of direct skipCommitConfirmation
refactor(commit): use config.OCO_SKIP_PUSH_PROMPT to control git push behavior
——————————————————
│
◇  ✔ Successfully committed
│
└  [feat/adding-skip-commit-and-skip-push 6fc7274] feat(config): add OCO_SKIP_COMMIT_CONFIRM to skip confirmation prompt feat(config): add OCO_SKIP_PUSH_PROMPT to skip push prompt refactor(commit): use config.OCO_SKIP_COMMIT_CONFIRM instead of direct skipCommitConfirmation refactor(commit): use config.OCO_SKIP_PUSH_PROMPT to control git push behavior
 2 files changed, 41 insertions(+), 5 deletions(-)
```

I hope this pull request will be accepted. The constant prompting can be tedious, and this change provides a much-needed quality-of-life improvement for users who want a faster, more direct commit process.