### PR TITLE
feat: enhance ignore file support with local and global configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,12 +327,38 @@ Once users have generated their desired commit message, they can proceed to comm
 
 ### Ignore files
 
-You can remove files from being sent to OpenAI by creating a `.opencommitignore` file. For example:
+You can remove files from being sent to OpenAI by creating ignore files. OpenCommit supports both local and global ignore files:
+
+#### Local ignore file
+
+Create a `.opencommitignore` file in your project root:
 
 ```ignorelang
 path/to/large-asset.zip
 **/*.jpg
+docs/generated/
+*.generated.ts
 ```
+
+#### Global ignore file
+
+Create a global `.opencommitignore` file in your home directory (`~/.opencommitignore`) to ignore files across all projects:
+
+```ignorelang
+*.log
+*.tmp
+.DS_Store
+node_modules/
+.env
+.env.local
+dist/
+build/
+coverage/
+.vscode/
+.idea/
+```
+
+**Priority:** Local ignore rules are applied after global rules. Both files use [gitignore syntax](https://git-scm.com/docs/gitignore#_pattern_format).
 
 This helps prevent opencommit from uploading artifacts and large files.
 

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -1,7 +1,8 @@
 import { execa } from 'execa';
-import { readFileSync } from 'fs';
+import { readFileSync, existsSync } from 'fs';
 import ignore, { Ignore } from 'ignore';
 import { join } from 'path';
+import { homedir } from 'os';
 import { outro, spinner } from '@clack/prompts';
 
 export const assertGitRepo = async () => {
@@ -18,14 +19,27 @@ export const assertGitRepo = async () => {
 
 export const getOpenCommitIgnore = async (): Promise<Ignore> => {
   const gitDir = await getGitDir();
-
   const ig = ignore();
 
-  try {
-    ig.add(
-      readFileSync(join(gitDir, '.opencommitignore')).toString().split('\n')
-    );
-  } catch (e) {}
+  const globalIgnorePath = join(homedir(), '.opencommitignore');
+  if (existsSync(globalIgnorePath)) {
+    try {
+      const globalIgnoreContent = readFileSync(globalIgnorePath, 'utf8');
+      ig.add(globalIgnoreContent.split('\n'));
+    } catch (e) {
+      // do nothing
+    }
+  }
+
+  const localIgnorePath = join(gitDir, '.opencommitignore');
+  if (existsSync(localIgnorePath)) {
+    try {
+      const localIgnoreContent = readFileSync(localIgnorePath, 'utf8');
+      ig.add(localIgnoreContent.split('\n'));
+    } catch (e) {
+      // do nothing
+    }
+  }
 
   return ig;
 };


### PR DESCRIPTION
issue: #344 

This pull request enhances file ignore functionality in OpenCommit by introducing support for global ignore files, improving usability and flexibility. The changes include updates to the documentation and the implementation of the ignore file handling logic.

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L330-R362): Updated to describe the support for both local and global `.opencommitignore` files. Added examples for each type and clarified priority rules (local rules override global rules).

### Code Enhancements:

* `src/utils/git.ts`: 
  - Imported `existsSync` from `fs` and `homedir` from `os` to enable checking for and locating global ignore files.
  - Modified the `getOpenCommitIgnore` function to:
    - Check for a global `.opencommitignore` file in the user's home directory and apply its rules if present.
    - Retain support for local `.opencommitignore` files, with local rules taking precedence over global rules.