### PR TITLE
Add OCO_HOOK_AUTO_UNCOMMENT to environment configuration

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -954,7 +954,8 @@ const getEnvConfig = (envPath: string) => {
     OCO_TEST_MOCK_TYPE: process.env.OCO_TEST_MOCK_TYPE,
     OCO_OMIT_SCOPE: parseConfigVarValue(process.env.OCO_OMIT_SCOPE),
 
-    OCO_GITPUSH: parseConfigVarValue(process.env.OCO_GITPUSH) // todo: deprecate
+    OCO_GITPUSH: parseConfigVarValue(process.env.OCO_GITPUSH), // todo: deprecate
+    OCO_HOOK_AUTO_UNCOMMENT: parseConfigVarValue(process.env.OCO_HOOK_AUTO_UNCOMMENT)
   };
 };
 


### PR DESCRIPTION
The new option `OCO_HOOK_AUTO_UNCOMMENT` in #494 is not exposed as en environment variable. This PR reads this value from the environment, like other configuration values