### PR TITLE
fix(git): don't use external diff tools when getting git diff

### DIFF
--- a/out/cli.cjs
+++ b/out/cli.cjs
@@ -85950,7 +85950,7 @@ ${excludedFiles.join(
   const diffableFiles = files.filter((file) => !isFileExcludedFromDiff(file));
   const { stdout: diff } = await execa(
     "git",
-    ["diff", "--staged", "--", ...diffableFiles],
+    ["diff", "--staged", "--no-ext-diff", "--", ...diffableFiles],
     { cwd: gitDir }
   );
   return diff;

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -134,7 +134,7 @@ export const getDiff = async ({ files }: { files: string[] }) => {
 
   const { stdout: diff } = await execa(
     'git',
-    ['diff', '--staged', '--', ...diffableFiles],
+    ['diff', '--staged', '--no-ext-diff', '--', ...diffableFiles],
     { cwd: gitDir }
   );
 

--- a/test/e2e/oneFile.test.ts
+++ b/test/e2e/oneFile.test.ts
@@ -7,9 +7,11 @@ import {
   prepareEnvironment,
   prepareRepo,
   runCli,
+  runGit,
   startMockOpenAiServer,
   appendRepoFile,
-  waitForExit
+  waitForExit,
+  writeRepoFile
 } from './utils';
 
 it('cli flow to generate commit message for 1 new file (staged)', async () => {
@@ -57,6 +59,58 @@ it('cli flow to generate commit message for 1 new file (staged)', async () => {
         await getCurrentBranchName(gitDir)
       )
     ).toBe('feat(cli): commit one staged file through the CLI');
+  } finally {
+    await server.cleanup();
+    await cleanup();
+  }
+});
+
+it('cli ignores configured external diff tools when generating the prompt', async () => {
+  const { gitDir, cleanup } = await prepareEnvironment({ remotes: 0 });
+  const server = await startMockOpenAiServer(
+    'fix(diff): use the staged patch in the prompt'
+  );
+
+  try {
+    await prepareRepo(
+      gitDir,
+      {
+        'index.ts': 'console.log("before");\n'
+      },
+      {
+        stage: true,
+        commitMessage: 'add initial file'
+      }
+    );
+    writeRepoFile(gitDir, 'index.ts', 'console.log("after");\n');
+    await runGit(['add', 'index.ts'], gitDir);
+    await runGit(
+      ['config', 'diff.external', 'echo OCO_EXTERNAL_DIFF_USED'],
+      gitDir
+    );
+
+    const oco = await runCli(['--yes'], {
+      cwd: gitDir,
+      env: getMockOpenAiEnv(server.baseUrl)
+    });
+
+    expect(await waitForExit(oco)).toBe(0);
+    await assertHeadCommit(
+      gitDir,
+      'fix(diff): use the staged patch in the prompt'
+    );
+
+    const requestContents = server.requestBodies
+      .flatMap(
+        (body) =>
+          (body as { messages?: Array<{ content: string }> }).messages ?? []
+      )
+      .map((message) => message.content)
+      .join('\n');
+
+    expect(requestContents).toContain('-console.log("before");');
+    expect(requestContents).toContain('+console.log("after");');
+    expect(requestContents).not.toContain('OCO_EXTERNAL_DIFF_USED');
   } finally {
     await server.cleanup();
     await cleanup();


### PR DESCRIPTION
i use `difftastic`, and it was common for LLMs to think that no diff was provided because difftastic can eliminate enough context to make diffs person-readable, but not LLM-readable.

adding `--no-ext-diff` to our `git diff` command should help to avoid this.