### PR TITLE
fix(anthropic): remove `top_p` parameter for Claude 4.5 models

### DIFF
--- a/src/engine/anthropic.ts
+++ b/src/engine/anthropic.ts
@@ -41,7 +41,7 @@ export class AnthropicEngine implements AiEngine {
     };
 
     // add top_p for non-4.5 models
-    if (!params.model.includes('-4-5') || !params.model.includes('claude')) {
+    if (!/claude.*-4-5/.test(params.model)) {
       params.top_p = 0.1;
     }
 


### PR DESCRIPTION
removes the `top_p` parameter if the configured model string contains `-4-5`. this fixes #520 , where opencommit will fail because Anthropic does not support *both* `temperature` and `top_p` for their 4.5 models.