### PR TITLE
fix: Disambiguate error message when running from non-git repo

### DIFF
--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -52,11 +52,10 @@ const generateCommitMessageFromGitDiff = async ({
   fullGitMojiSpec = false,
   skipCommitConfirmation = false
 }: GenerateCommitMessageFromGitDiffParams): Promise<void> => {
-  await assertGitRepo();
   const commitGenerationSpinner = spinner();
-  commitGenerationSpinner.start('Generating the commit message');
-
   try {
+    await assertGitRepo();
+    commitGenerationSpinner.start('Generating the commit message');
     let commitMessage = await generateCommitMessageByDiff(
       diff,
       fullGitMojiSpec,
@@ -226,6 +225,14 @@ export async function commit(
   fullGitMojiSpec: boolean = false,
   skipCommitConfirmation: boolean = false
 ) {
+  try {
+    await assertGitRepo();
+  } catch (error) {
+    const err = error as Error;
+    outro(`${chalk.red('✖')} ${err?.message || err}`);
+    process.exit(1);
+  }
+  
   if (isStageAllFlag) {
     const changedFiles = await getChangedFiles();
 


### PR DESCRIPTION
Add the assertGitRepo() check earlier in the commit pipeline to display:

```
—  ✖ Error: Command failed with exit code 128: git rev-parse
fatal: not a git repository (or any of the parent directories): .git
```

instead of:

```
|
—  No changes detected
```

feat(commit.ts): add error handling for assertGitRepo in top level commit to improve user feedback.
fix(commit.ts: move assertGitRepo call into try/catch block to handle appropriately