### PR TITLE
fix(commitlint): Support i18n translations in consistency prompt generation

### DIFF
--- a/src/modules/commitlint/config.ts
+++ b/src/modules/commitlint/config.ts
@@ -56,7 +56,7 @@ export const configureCommitlintIntegration = async (force = false) => {
   const prompts = inferPromptsFromCommitlintConfig(commitLintConfig as any);
 
   const consistencyPrompts =
-    commitlintPrompts.GEN_COMMITLINT_CONSISTENCY_PROMPT(prompts);
+    commitlintPrompts.GEN_COMMITLINT_CONSISTENCY_PROMPT(prompts, translation);
 
   // debug prompt which will generate a consistency
   // await fs.writeFile(

--- a/src/modules/commitlint/prompts.ts
+++ b/src/modules/commitlint/prompts.ts
@@ -12,9 +12,9 @@ import {
 import { getConfig } from '../../commands/config';
 import { i18n, I18nLocals } from '../../i18n';
 import { IDENTITY, INIT_DIFF_PROMPT } from '../../prompts';
+import { ConsistencyPrompt } from './types';
 
 const config = getConfig();
-const translation = i18n[(config.OCO_LANGUAGE as I18nLocals) || 'en'];
 
 type DeepPartial<T> = {
   [P in keyof T]?: {
@@ -214,7 +214,8 @@ const STRUCTURE_OF_COMMIT = config.OCO_OMIT_SCOPE
 
 // Prompt to generate LLM-readable rules based on @commitlint rules.
 const GEN_COMMITLINT_CONSISTENCY_PROMPT = (
-  prompts: string[]
+  prompts: string[],
+  translation: ConsistencyPrompt
 ): OpenAI.Chat.Completions.ChatCompletionMessageParam[] => [
   {
     role: 'system',
@@ -233,15 +234,17 @@ Commit Message Conventions:
 - ${prompts.join('\n- ')}
 
 JSON Output Format:
-- The JSON output should contain the commit messages for a bug fix and a new feature in the following format:
+- You MUST write all commit messages and descriptions in ${
+      translation.localLanguage
+    } and output them in the following JSON format. Use the exact language and writing style as shown in the example:
 \`\`\`json
 {
-  "localLanguage": "${translation.localLanguage}",
-  "commitFix": "<Header of commit for bug fix with scope>",
-  "commitFeat": "<Header of commit for feature with scope>",
-  "commitFixOmitScope": "<Header of commit for bug fix without scope>",
-  "commitFeatOmitScope": "<Header of commit for feature without scope>",
-  "commitDescription": "<Description of commit for both the bug fix and the feature>"
+  "localLanguage": ${JSON.stringify(translation.localLanguage)},
+  "commitFix": ${JSON.stringify(translation.commitFix)},
+  "commitFeat": ${JSON.stringify(translation.commitFeat)},
+  "commitFixOmitScope": ${JSON.stringify(translation.commitFixOmitScope)},
+  "commitFeatOmitScope": ${JSON.stringify(translation.commitFeatOmitScope)},
+  "commitDescription": ${JSON.stringify(translation.commitDescription)}
 }
 \`\`\`
 - The "commitDescription" should not include the commit message's header, only the description.


### PR DESCRIPTION
## Problem

When generating `.opencommit-commitlint` configuration with `OCO_LANGUAGE=zh_TW` (or other non-English languages), the LLM was generating consistency examples in English instead of using the translated content from the corresponding i18n JSON files (e.g., `zh_TW.json`).

## Solution

1. Modified `GEN_COMMITLINT_CONSISTENCY_PROMPT` function to accept translation parameter
2. Added explicit instructions and reference examples to guide LLM to use correct language

## Changes

- `src/modules/commitlint/prompts.ts`: Added translation parameter and reference examples
- `src/modules/commitlint/config.ts`: Pass translation object to prompt generation

## Testing

```bash
OCO_LANGUAGE=zh_TW OCO_PROMPT_MODULE=@commitlint oco commitlint force
```