### PR TITLE
feat(prepare-commit-msg): Continue creating a commit even when an AI provider error occurs

### DIFF
--- a/src/generateCommitMessageFromGitDiff.ts
+++ b/src/generateCommitMessageFromGitDiff.ts
@@ -166,11 +166,7 @@ export const generateCommitMessageByDiff = async (
         context
       );
 
-      const commitMessages = [] as string[];
-      for (const promise of commitMessagePromises) {
-        commitMessages.push((await promise) as string);
-        await delay(2000);
-      }
+      const commitMessages = await Promise.all(commitMessagePromises);
 
       return commitMessages.join('\n\n');
     }


### PR DESCRIPTION
## Why is this PR needed?
I encountered an issue when using the prepare-commit-msg hook to automatically generate commit messages. When an API call to the AI provider fails, the prepare-commit-msg hook also fails, and a commit cannot be created unless the hook is disabled. Such API failures can occur due to network issues or other temporary problems.

It is annoying to have to run `oco hook unset; git commit; oco hook set` every time to work around this issue.

## What has changed
- The hook now continues to create a commit even when an error occurs by catching the error. To make it noticeable when such an issue occurs, the error message is  written to the temporary commit message file.
  - The `commitMessagePromises` loop previously prevented errors from being caught; is has been replaced with `Promise.all` instead.

## How does this work
When a commit is created during a network issue, the following message is displayed in your `$EDITOR` :

```txt
 

# ---------- [OpenCommit] ---------- #
# Failed to generate the commit message.
# To cancel the commit, just close this window without making any changes.

# Error: Connection error.


# Please enter the commit message for your changes. Lines starting
# with '#' will be ignored, and an empty message aborts the commit.
#
# On branch error-on-hook
```