### PR TITLE
fix(OCO_HOOK_AUTO_UNCOMMENT): set value using `oco config set`

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -840,6 +840,7 @@ export const configValidators = {
       typeof value === 'boolean',
       'Must be true or false'
     );
+    return value;
   },
 
   [CONFIG_KEYS.OCO_OLLAMA_THINK](value: any) {
@@ -848,7 +849,6 @@ export const configValidators = {
       typeof value === 'boolean',
       'Must be true or false'
     );
-    return value;
   }
 };
 


### PR DESCRIPTION
The option OCO_HOOK_AUTO_UNCOMMENT introduced in https://github.com/di-sukharev/opencommit/pull/494 cannot be set using `oco config set OCO_HOOK_AUTO_UNCOMMENT=true`. This PR fixes the issue to correctly update `.opencommit`.