### PR TITLE
chore: add biome.json as an opt-in alternative to Prettier and ESLint

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+
+  "files": {
+    "ignoreUnknown": true,
+    "includes": ["**", "!!build", "!!dist", "!!out"]
+  },
+
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineEnding": "lf"
+  },
+
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "jsxQuoteStyle": "double",
+      "trailingCommas": "none",
+      "semicolons": "always"
+    }
+  },
+
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "suspicious": {
+        "noConsole": "error"
+      },
+      "style": {
+        "noNonNullAssertion": "off"
+      }
+    }
+  },
+
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds a `biome.json` configuration file for developers who prefer [Biome](https://biomejs.dev/) over Prettier and ESLint.

## Why

The project currently provides `.prettierrc` and `.eslintrc.json` as the canonical tooling. This PR does **not** replace them — Prettier and ESLint remain the primary setup. `biome.json` is purely opt-in for contributors who already use Biome in their workflow.

## How

The configuration is intentionally kept aligned with the existing rules:

| Existing rule | Biome equivalent |
|---|---|
| `.prettierrc` — `singleQuote: true` | `javascript.formatter.quoteStyle: "single"` |
| `.prettierrc` — `trailingComma: "none"` | `javascript.formatter.trailingCommas: "none"` |
| `.prettierignore` — `build`, `dist`, `out` | `files.includes` force-ignore (`!!`) |
| `eslint:recommended` + `@typescript-eslint/recommended` | `linter.rules.recommended: true` |
| `no-console: "error"` | `linter.rules.suspicious.noConsole: "error"` |
| `@typescript-eslint/no-non-null-assertion: "off"` | `linter.rules.style.noNonNullAssertion: "off"` |
| `simple-import-sort` + `import/first` + `import/no-duplicates` | `assist.actions.source.organizeImports: "on"` |

VCS integration is enabled so Biome respects the existing `.gitignore` automatically.

## Notes

- No existing files are modified.
- Contributors using Prettier + ESLint are completely unaffected.
- The schema targets Biome v2 (`2.4.x`).