### PR TITLE
feat(deps): add undici dependency version 8.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "inquirer": "^9.1.4",
     "openai": "^4.57.0",
     "punycode": "^2.3.1",
+    "undici": "8.4.1",
     "zod": "^3.23.8"
   },
   "overrides": {


### PR DESCRIPTION
## Summary

Add `undici@8.4.1` as an explicit dependency.

## Why

This project uses `Agent`, `ProxyAgent`, and `setGlobalDispatcher` from `undici` in the proxy setup logic.

According to the Undici documentation, these APIs are not provided by Node.js built-in `fetch` alone. Built-in `fetch` covers the standard request interface, but advanced networking features such as `ProxyAgent`, `Socks5Agent`, and `MockAgent` require the `undici` package directly.

Since OpenCommit uses `ProxyAgent` and `setGlobalDispatcher` to configure proxy behavior, `undici` should be declared explicitly in `dependencies`.

[https://github.com/nodejs/undici](https://github.com/nodejs/undici)
## Changes

- add `undici@8.4.1` to `dependencies`

## Verification

- confirmed `src/utils/proxy.ts` imports and uses `Agent`, `ProxyAgent`, and `setGlobalDispatcher` from `undici`
- confirmed `pnpm build` succeeds after adding the dependency