### PR TITLE
fix: cancel edited commit message on interrupt

### DIFF
--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -132,6 +132,8 @@ ${chalk.grey('——————————————————')}`
         initialValue: commitMessage
       });
 
+      if (isCancel(textResponse)) process.exit(1);
+
       commitMessage = textResponse.toString();
     }
 

--- a/test/e2e/cliBehavior.test.ts
+++ b/test/e2e/cliBehavior.test.ts
@@ -159,6 +159,47 @@ it('cli flow allows editing the generated commit message before committing', asy
   }
 });
 
+it('cli flow cancels when editing the generated commit message is interrupted', async () => {
+  const { gitDir, cleanup } = await prepareEnvironment();
+  const server = await startMockOpenAiServer(
+    'fix(cli): allow editing the generated message'
+  );
+
+  try {
+    await prepareRepo(
+      gitDir,
+      {
+        'index.ts': 'console.log("Hello World");\n'
+      },
+      { stage: true }
+    );
+
+    const oco = await runCli([], {
+      cwd: gitDir,
+      env: getMockOpenAiEnv(server.baseUrl)
+    });
+
+    expect(
+      await oco.findByText('Confirm the commit message?')
+    ).toBeInTheConsole();
+    oco.userEvent.keyboard('[ArrowDown][ArrowDown][Enter]');
+
+    expect(
+      await oco.findByText(
+        'Please edit the commit message: (press Enter to continue)'
+      )
+    ).toBeInTheConsole();
+    oco.process.stdin.write('\x03');
+
+    expect(await waitForExit(oco)).toBe(1);
+    expect(await oco.queryByText('Successfully committed')).not.toBeInTheConsole();
+    await assertGitStatus(gitDir, 'A  index.ts');
+  } finally {
+    await server.cleanup();
+    await cleanup();
+  }
+});
+
 it('cli flow regenerates the message when the user rejects the first suggestion', async () => {
   const { gitDir, cleanup } = await prepareEnvironment();
   const server = await startMockOpenAiServer(({ requestIndex }) => ({

--- a/test/e2e/cliBehavior.test.ts
+++ b/test/e2e/cliBehavior.test.ts
@@ -192,7 +192,9 @@ it('cli flow cancels when editing the generated commit message is interrupted', 
     oco.process.stdin.write('\x03');
 
     expect(await waitForExit(oco)).toBe(1);
-    expect(await oco.queryByText('Successfully committed')).not.toBeInTheConsole();
+    expect(
+      await oco.queryByText('Successfully committed')
+    ).not.toBeInTheConsole();
     await assertGitStatus(gitDir, 'A  index.ts');
   } finally {
     await server.cleanup();


### PR DESCRIPTION
Fixes #560.

This prevents the Edit commit-message prompt from treating `Ctrl+C` as a literal commit message.

Root cause:
- `@clack/prompts` returns a cancel symbol when the text prompt is interrupted.
- The Edit path converted that value with `toString()`, so `Symbol(clack:cancel)` could be passed to `git commit -m`.

Changes:
- Check `isCancel(textResponse)` before using the edited commit message.
- Add an e2e regression test that interrupts the Edit text prompt and verifies no commit is created.
- Keep the normal Edit flow covered to make sure edited commit messages still commit correctly.

Verification:
- `npm run build`
- `npx jest test/e2e/cliBehavior.test.ts -t "cli flow cancels when editing the generated commit message is interrupted"`
- `npx jest test/e2e/cliBehavior.test.ts -t "cli flow allows editing the generated commit message before committing"`
- `npm run lint`
