### PR TITLE
fix(anthropic): pass baseURL to client and handle thinking model responses

### DIFF
--- a/src/engine/anthropic.ts
+++ b/src/engine/anthropic.ts
@@ -21,6 +21,10 @@ export class AnthropicEngine implements AiEngine {
     this.config = config;
     const clientOptions: any = { apiKey: this.config.apiKey };
 
+    if (this.config.baseURL) {
+      clientOptions.baseURL = this.config.baseURL;
+    }
+
     const proxy = config.proxy;
     if (proxy) {
       clientOptions.httpAgent = new HttpsProxyAgent(proxy);
@@ -65,7 +69,8 @@ export class AnthropicEngine implements AiEngine {
 
       const data = await this.client.messages.create(params);
 
-      const message = data?.content[0].text;
+      const textBlock = data?.content?.find((b) => b.type === 'text');
+      const message = textBlock && 'text' in textBlock ? textBlock.text : undefined;
       let content = message;
       return removeContentTags(content, 'think');
     } catch (error) {

--- a/src/engine/anthropic.ts
+++ b/src/engine/anthropic.ts
@@ -70,7 +70,8 @@ export class AnthropicEngine implements AiEngine {
       const data = await this.client.messages.create(params);
 
       const textBlock = data?.content?.find((b) => b.type === 'text');
-      const message = textBlock && 'text' in textBlock ? textBlock.text : undefined;
+      const message =
+        textBlock && 'text' in textBlock ? textBlock.text : undefined;
       let content = message;
       return removeContentTags(content, 'think');
     } catch (error) {

--- a/test/unit/anthropic.test.ts
+++ b/test/unit/anthropic.test.ts
@@ -85,4 +85,34 @@ describe('AnthropicEngine', () => {
       })
     );
   });
+
+  it('forwards a custom baseURL to the Anthropic client', () => {
+    const engine = new AnthropicEngine({
+      ...baseConfig,
+      model: 'claude-sonnet-4-6',
+      baseURL: 'https://my-proxy.example.com/anthropic'
+    });
+
+    expect(engine.client.baseURL).toBe(
+      'https://my-proxy.example.com/anthropic'
+    );
+  });
+
+  it('extracts the text block when the response starts with a thinking block', async () => {
+    const engine = new AnthropicEngine({
+      ...baseConfig,
+      model: 'claude-sonnet-4-6'
+    });
+
+    jest.spyOn(engine.client.messages, 'create').mockResolvedValue({
+      content: [
+        { type: 'thinking', thinking: 'analyzing the diff step by step' },
+        { type: 'text', text: 'feat(anthropic): support thinking models' }
+      ]
+    } as any);
+
+    const result = await engine.generateCommitMessage(messages);
+
+    expect(result).toBe('feat(anthropic): support thinking models');
+  });
 });


### PR DESCRIPTION
## Summary

- **Pass `baseURL` from config to the Anthropic SDK client.** Without this, requests always go to `https://api.anthropic.com` even when `OCO_API_URL` is configured, resulting in 403 errors for users with custom API endpoints (e.g. corporate proxies).

- **Find the `text` content block instead of accessing `content[0].text`.** Models with extended thinking (e.g. Claude with thinking enabled, or thinking-capable models behind proxies) return a `thinking` block at index 0 and the actual text at index 1. The old code gets `undefined` from `content[0].text` since the thinking block has no `text` property, producing empty commit messages.

## Reproduction

1. Set `OCO_AI_PROVIDER=anthropic` with a custom `OCO_API_URL` pointing to a proxy
2. Run `oco` → gets **403 Forbidden** (Bug 1)
3. After manually fixing baseURL, run `oco` with a thinking model → gets **empty commit message** (Bug 2)

## Fix

```diff
// Bug 1: pass baseURL
 const clientOptions: any = { apiKey: this.config.apiKey };
+if (this.config.baseURL) {
+  clientOptions.baseURL = this.config.baseURL;
+}

// Bug 2: find text block instead of content[0]
-const message = data?.content[0].text;
+const textBlock = data?.content?.find((b) => b.type === 'text');
+const message = textBlock && 'text' in textBlock ? textBlock.text : undefined;
```

## Test plan

- [x] Verified with custom `OCO_API_URL` — no more 403
- [x] Verified with thinking model (GLM-5.1 via proxy) — commit message correctly extracted from `text` block
- [ ] Non-thinking models still work (fallback: first text block is at index 0 as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)