### PR TITLE
fix(anthropic): support Claude 4.6+ and refresh default model list

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -70,11 +70,10 @@ export const MODEL_LIST = {
   ],
 
   anthropic: [
-    'claude-sonnet-4-20250514',
-    'claude-opus-4-20250514',
-    'claude-3-7-sonnet-20250219',
-    'claude-3-5-sonnet-20241022',
-    'claude-3-5-haiku-20241022'
+    'claude-sonnet-4-6',
+    'claude-opus-4-8',
+    'claude-sonnet-4-5-20250929',
+    'claude-haiku-4-5-20251001'
   ],
 
   gemini: [
@@ -893,7 +892,7 @@ export const PROVIDER_API_KEY_URLS: Record<string, string | null> = {
 
 export const RECOMMENDED_MODELS: Record<string, string> = {
   [OCO_AI_PROVIDER_ENUM.OPENAI]: 'gpt-4o-mini',
-  [OCO_AI_PROVIDER_ENUM.ANTHROPIC]: 'claude-sonnet-4-20250514',
+  [OCO_AI_PROVIDER_ENUM.ANTHROPIC]: 'claude-sonnet-4-6',
   [OCO_AI_PROVIDER_ENUM.GEMINI]: 'gemini-1.5-flash',
   [OCO_AI_PROVIDER_ENUM.GROQ]: 'llama3-70b-8192',
   [OCO_AI_PROVIDER_ENUM.MISTRAL]: 'mistral-small-latest',

--- a/src/engine/anthropic.ts
+++ b/src/engine/anthropic.ts
@@ -46,8 +46,8 @@ export class AnthropicEngine implements AiEngine {
       max_tokens: this.config.maxTokensOutput
     };
 
-    // add top_p for non-4.5 models
-    if (!/claude.*-4-5/.test(params.model)) {
+    // Anthropic rejects simultaneous temperature and top_p on Claude 4.5+
+    if (!/claude.*-4-(?:5|[6-9])/.test(params.model)) {
       params.top_p = 0.1;
     }
 

--- a/src/utils/engineErrorHandler.ts
+++ b/src/utils/engineErrorHandler.ts
@@ -93,7 +93,6 @@ function isModelNotFoundMessage(message: string): boolean {
     (lowerMessage.includes('model') &&
       (lowerMessage.includes('not found') ||
         lowerMessage.includes('does not exist') ||
-        lowerMessage.includes('invalid') ||
         lowerMessage.includes('pull'))) ||
     lowerMessage.includes('does_not_exist')
   );
@@ -171,6 +170,10 @@ export function normalizeEngineError(
   }
 
   // Handle based on error message content
+  if (statusCode === 400) {
+    return error instanceof Error ? error : new Error(message);
+  }
+
   if (isModelNotFoundMessage(message)) {
     return new ModelNotFoundError(model, provider, 404);
   }

--- a/test/unit/anthropic.test.ts
+++ b/test/unit/anthropic.test.ts
@@ -1,0 +1,88 @@
+import { OpenAI } from 'openai';
+import { AnthropicEngine } from '../../src/engine/anthropic';
+
+describe('AnthropicEngine', () => {
+  const baseConfig = {
+    apiKey: 'test-anthropic-key',
+    maxTokensInput: 4096,
+    maxTokensOutput: 256
+  };
+
+  const messages: Array<OpenAI.Chat.Completions.ChatCompletionMessageParam> = [
+    { role: 'system', content: 'system message' },
+    { role: 'user', content: 'diff --git a/file b/file' }
+  ];
+
+  it('does not send top_p for Claude 4.5 models', async () => {
+    const engine = new AnthropicEngine({
+      ...baseConfig,
+      model: 'claude-haiku-4-5-20251001'
+    });
+
+    const create = jest
+      .spyOn(engine.client.messages, 'create')
+      .mockResolvedValue({
+        content: [{ type: 'text', text: 'feat(theme): update colors' }]
+      } as any);
+
+    await engine.generateCommitMessage(messages);
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'claude-haiku-4-5-20251001',
+        temperature: 0,
+        max_tokens: 256
+      })
+    );
+    expect(create).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        top_p: expect.anything()
+      })
+    );
+  });
+
+  it('does not send top_p for Claude 4.6+ models', async () => {
+    const engine = new AnthropicEngine({
+      ...baseConfig,
+      model: 'claude-sonnet-4-6'
+    });
+
+    const create = jest
+      .spyOn(engine.client.messages, 'create')
+      .mockResolvedValue({
+        content: [{ type: 'text', text: 'feat(theme): update colors' }]
+      } as any);
+
+    await engine.generateCommitMessage(messages);
+
+    expect(create).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        top_p: expect.anything()
+      })
+    );
+  });
+
+  it('sends top_p for legacy Claude models', async () => {
+    const engine = new AnthropicEngine({
+      ...baseConfig,
+      model: 'claude-sonnet-4-20250514'
+    });
+
+    const create = jest
+      .spyOn(engine.client.messages, 'create')
+      .mockResolvedValue({
+        content: [{ type: 'text', text: 'feat(theme): update colors' }]
+      } as any);
+
+    await engine.generateCommitMessage(messages);
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'claude-sonnet-4-20250514',
+        temperature: 0,
+        top_p: 0.1,
+        max_tokens: 256
+      })
+    );
+  });
+});

--- a/test/unit/engineErrorHandler.test.ts
+++ b/test/unit/engineErrorHandler.test.ts
@@ -1,0 +1,33 @@
+import { normalizeEngineError } from '../../src/utils/engineErrorHandler';
+import { ModelNotFoundError } from '../../src/utils/errors';
+
+describe('normalizeEngineError', () => {
+  it('does not classify Anthropic temperature/top_p 400 as model not found', () => {
+    const error = Object.assign(
+      new Error(
+        '`temperature` and `top_p` cannot both be specified for this model. Please use only one.'
+      ),
+      { status: 400 }
+    );
+
+    const normalized = normalizeEngineError(error, 'anthropic', 'claude-sonnet-4-6');
+
+    expect(normalized).not.toBeInstanceOf(ModelNotFoundError);
+    expect(normalized.message).toContain('temperature');
+  });
+
+  it('classifies genuine model-not-found errors', () => {
+    const error = Object.assign(
+      new Error('model: claude-sonnet-4-20250514 not found'),
+      { status: 404 }
+    );
+
+    const normalized = normalizeEngineError(
+      error,
+      'anthropic',
+      'claude-sonnet-4-20250514'
+    );
+
+    expect(normalized).toBeInstanceOf(ModelNotFoundError);
+  });
+});

--- a/test/unit/engineErrorHandler.test.ts
+++ b/test/unit/engineErrorHandler.test.ts
@@ -10,7 +10,11 @@ describe('normalizeEngineError', () => {
       { status: 400 }
     );
 
-    const normalized = normalizeEngineError(error, 'anthropic', 'claude-sonnet-4-6');
+    const normalized = normalizeEngineError(
+      error,
+      'anthropic',
+      'claude-sonnet-4-6'
+    );
 
     expect(normalized).not.toBeInstanceOf(ModelNotFoundError);
     expect(normalized.message).toContain('temperature');


### PR DESCRIPTION
## Summary

Fixes #566 — opencommit hanging on "Generating the commit message" when using current Anthropic models.

- **Extend Claude 4.5 `top_p` exemption to 4.6+** — `claude-sonnet-4-6` and friends no longer send both `temperature` and `top_p` (Anthropic rejects that with a 400)
- **Stop misclassifying 400s as model-not-found** — removes the overly broad `invalid` message heuristic and bails early on HTTP 400, so the spinner no longer hides the model picker on parameter errors
- **Refresh Anthropic fallback / recommended models** — replace retired June 2026 IDs with current models (`claude-sonnet-4-6`, `claude-opus-4-8`, etc.)

Builds on #520 / PR #521 (4.5 fix) which did not cover 4.6+.

## Test plan

- [x] `npm run test` — all 50 unit tests pass
- [x] `npm run lint` — biome + tsc clean
- [x] New `test/unit/anthropic.test.ts` — verifies `top_p` omitted for 4.5/4.6+, kept for legacy IDs
- [x] New `test/unit/engineErrorHandler.test.ts` — verifies temperature/`top_p` 400 is not treated as model-not-found