### PR TITLE
fix(gemini): remove `maxOutputTokens` from generation config

### DIFF
--- a/src/engine/gemini.ts
+++ b/src/engine/gemini.ts
@@ -126,7 +126,6 @@ export class GeminiEngine implements AiEngine {
           }
         ],
         generationConfig: {
-          maxOutputTokens: this.config.maxTokensOutput,
           temperature: 0,
           topP: 0.1
         }

--- a/test/unit/gemini.test.ts
+++ b/test/unit/gemini.test.ts
@@ -82,7 +82,6 @@ describe('GeminiEngine', () => {
           }
         ],
         generationConfig: expect.objectContaining({
-          maxOutputTokens: 256,
           temperature: 0,
           topP: 0.1
         })


### PR DESCRIPTION
Fixes #523.

Removing the `maxOutputTokens` constraint from Gemini's generation config allows the model to generate responses without an artificial token limit, preventing potential truncation of longer outputs.

Tested with:

- `OCO_AI_PROVIDER=gemini`
- `OCO_MODEL=gemini-2.5-flash`
- Patched version of `oco` v3.3.5.
- Tested on a branch with 10 files changed and a couple hundred lines of changed code without truncation issues.

Output of `oco`:

```bash
> oco
┌  open-commit
│
◇  10 staged files:
  .github/actions/terraform-apply-stack/action.yml
  .github/workflows/ci.yml
  .github/workflows/deploy-platform-ui.yml
  .github/workflows/lambda-docker-reusable.yml
  .github/workflows/lambda-reuseable.yml
  .github/workflows/layer-reuseable.yml
  .github/workflows/publish-packages.yml
  .github/workflows/terraform-apply.yml
  .github/workflows/terraform-plan.yml
  scripts/setup.sh
│
◇  📝 Commit message generated
│
└  Generated commit message:
——————————————————
build(deps): update GitHub Actions to their latest major versions
build(scripts): update default Node.js version in setup script to 24.16.0

This commit updates all GitHub Actions used in the workflows to their latest major versions to benefit from new features, bug fixes, and security improvements. Specifically, `actions/checkout` is updated from v4 to v6, `pnpm/action-setup` from v3 to v4, `actions/setup-node` from v4 to v6, `astral-sh/setup-uv` from v4 to v8, `aws-actions/configure-aws-credentials` from v4 to v6 (and v2 to v6 in some cases), `docker/setup-qemu-action` from v3 to v4, and `docker/setup-buildx-action` from v3 to v4. Additionally, the `scripts/setup.sh` file is updated to default to Node.js version 24.16.0 if no `.nvmrc` file is found, ensuring that new setups use a more recent LTS version of Node.js.
——————————————————

│
◇  Confirm the commit message?
│  Yes
│
◇  ✔ Successfully committed
│
└  [chore/upgrade-node-workflow-version 242afb0] build(deps): update GitHub Actions to their latest major versions build(scripts): update default Node.js version in setup script to 24.16.0
 10 files changed, 44 insertions(+), 44 deletions(-)

│
◇  Do you want to run `git push`?
│  No
│
└  `git push` aborted
```