### PR TITLE
feat(migrations): support LLAMACPP and AIMLAPI AI providers

### DIFF
--- a/src/migrations/_run.ts
+++ b/src/migrations/_run.ts
@@ -43,7 +43,9 @@ export const runMigrations = async () => {
       OCO_AI_PROVIDER_ENUM.GROQ,
       OCO_AI_PROVIDER_ENUM.MISTRAL,
       OCO_AI_PROVIDER_ENUM.MLX,
-      OCO_AI_PROVIDER_ENUM.OPENROUTER
+      OCO_AI_PROVIDER_ENUM.OPENROUTER,
+      OCO_AI_PROVIDER_ENUM.LLAMACPP,
+      OCO_AI_PROVIDER_ENUM.AIMLAPI
     ].includes(config.OCO_AI_PROVIDER)
   ) {
     return;


### PR DESCRIPTION
Add OCO_AI_PROVIDER_ENUM.LLAMACPP and .AIMLAPI to the allowed providers check so migrations correctly handle these new backends.

Fixes this error when using llama.cpp:

```
Applying migration 00_use_single_api_key_and_url
│
└  Failed to apply migration 00_use_single_api_key_and_url: Error: Migration failed, set AI provider first. Run "oco config set OCO_AI_PROVIDER=<provider>", where <provider> is one of: ollama, llamacpp, openai, anthropic, gemini, azure, test, flowise, groq, mistral, mlx, deepseek, aimlapi, openrouter
```