### PR TITLE
fix(i18n): use ASCII colon and space in zh_CN/zh_TW commit examples

### DIFF
--- a/src/i18n/zh_CN.json
+++ b/src/i18n/zh_CN.json
@@ -1,8 +1,8 @@
 {
   "localLanguage": "简体中文",
-  "commitFix": "fix(server.ts)：将端口变量从小写port改为大写PORT",
-  "commitFeat": "feat(server.ts)：添加对process.env.PORT环境变量的支持",
+  "commitFix": "fix(server.ts): 将端口变量从小写port改为大写PORT",
+  "commitFeat": "feat(server.ts): 添加对process.env.PORT环境变量的支持",
   "commitDescription": "现在端口变量被命名为PORT，这提高了命名约定的一致性，因为PORT是一个常量。环境变量的支持使应用程序更加灵活，因为它现在可以通过process.env.PORT环境变量在任何可用端口上运行。",
-  "commitFixOmitScope": "fix：将端口变量从小写port改为大写PORT",
-  "commitFeatOmitScope": "feat：添加对process.env.PORT环境变量的支持"
+  "commitFixOmitScope": "fix: 将端口变量从小写port改为大写PORT",
+  "commitFeatOmitScope": "feat: 添加对process.env.PORT环境变量的支持"
 }

--- a/src/i18n/zh_TW.json
+++ b/src/i18n/zh_TW.json
@@ -1,8 +1,8 @@
 {
   "localLanguage": "繁體中文",
-  "commitFix": "修正(server.ts)：將端口變數從小寫端口改為大寫PORT",
-  "commitFeat": "功能(server.ts)：新增對process.env.PORT環境變數的支援",
+  "commitFix": "修正(server.ts): 將端口變數從小寫端口改為大寫PORT",
+  "commitFeat": "功能(server.ts): 新增對process.env.PORT環境變數的支援",
   "commitDescription": "現在port變數已更名為PORT，以符合命名慣例，因為PORT是一個常量。支援環境變數可以使應用程序更靈活，因為它現在可以通過process.env.PORT環境變數運行在任何可用端口上。",
-  "commitFixOmitScope": "修正：將端口變數從小寫端口改為大寫PORT",
-  "commitFeatOmitScope": "功能：新增對process.env.PORT環境變數的支援"
+  "commitFixOmitScope": "修正: 將端口變數從小寫端口改為大寫PORT",
+  "commitFeatOmitScope": "功能: 新增對process.env.PORT環境變數的支援"
 }


### PR DESCRIPTION
## Summary

The `commitFix`/`commitFeat`/`commitFixOmitScope`/`commitFeatOmitScope` few-shot examples in the Simplified and Traditional Chinese locales use a **fullwidth colon (U+FF1A)** between the type/scope and the subject. All 13 other locales use an ASCII colon plus a space.

| Locale   | Header separator |
|----------|------------------|
| en, de, fr, it, es_ES, pt_br, nl, ru, pl, cs, sv, ja, ko, vi_VN, th, tr, id_ID | `fix: ` (ASCII) |
| **zh_CN** | `fix(server.ts)：…` (fullwidth) |
| **zh_TW** | `修正(server.ts)：…` (fullwidth) |

## Problem

The fullwidth form is **not valid** in the Conventional Commits spec, which requires an ASCII `:` followed by a space. When the user selects `zh_CN` or `zh_TW`, the LLM tends to mirror the example and produces non-conforming headers such as:

```
fix(server.ts)：将端口变量…
修正：將端口變數…
```

That breaks downstream tooling that parses commit headers:
- `@commitlint` rules (`type-enum`, `header-format`)
- `semantic-release`, `release-please`, `changesets`
- any other conventional-commit-aware automation

## Change

Replace `：` with `: ` (ASCII colon + single space) in the four commit example strings of each file. **Type names (`修正` / `功能`) are intentionally left untouched** to keep the change minimal and scoped to the format regression — translating type names is a separate design discussion.

## Test plan

- [x] JSON validity verified with `python3 -m json.tool` and a `node` parse
- [ ] CI passes (the `build` step is `npx rimraf out && node esbuild.config.js`; this PR only touches i18n strings, no TS changes, so `tsc --noEmit` is unaffected)
- [ ] Manual: run `oco` with `OCO_LANGUAGE=zh_CN` and `OCO_LANGUAGE=zh_TW` and confirm generated commit headers use `fix: ` / `feat: ` form