### PR TITLE
fix(version): fetch latest version from public npm registry API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencommit",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "description": "Auto-generate impressive commits in 1 second. Killing lame commits with AI 🤯🔫",
   "keywords": [
     "git",

--- a/src/version.ts
+++ b/src/version.ts
@@ -9,9 +9,7 @@ export const getOpenCommitLatestVersion = async (): Promise<
   string | undefined
 > => {
   try {
-    const response = await fetch(
-      `${NPM_REGISTRY}/${PACKAGE_NAME}/latest`
-    );
+    const response = await fetch(`${NPM_REGISTRY}/${PACKAGE_NAME}/latest`);
 
     if (!response.ok) {
       return undefined;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,14 +1,25 @@
-import { outro } from '@clack/prompts';
-import { execa } from 'execa';
+const NPM_REGISTRY = 'https://registry.npmjs.org';
+const PACKAGE_NAME = 'opencommit';
+
+type NpmLatestResponse = {
+  version?: string;
+};
 
 export const getOpenCommitLatestVersion = async (): Promise<
   string | undefined
 > => {
   try {
-    const { stdout } = await execa('npm', ['view', 'opencommit', 'version']);
-    return stdout;
-  } catch (_) {
-    outro('Error while getting the latest version of opencommit');
+    const response = await fetch(
+      `${NPM_REGISTRY}/${PACKAGE_NAME}/latest`
+    );
+
+    if (!response.ok) {
+      return undefined;
+    }
+
+    const data = (await response.json()) as NpmLatestResponse;
+    return data.version;
+  } catch {
     return undefined;
   }
 };

--- a/test/unit/version.test.ts
+++ b/test/unit/version.test.ts
@@ -1,0 +1,37 @@
+import { getOpenCommitLatestVersion } from '../../src/version';
+
+describe('getOpenCommitLatestVersion', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('fetches the latest version from the public npm registry', async () => {
+    globalThis.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: '3.3.9' })
+    }) as typeof fetch;
+
+    await expect(getOpenCommitLatestVersion()).resolves.toBe('3.3.9');
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://registry.npmjs.org/opencommit/latest'
+    );
+  });
+
+  it('returns undefined when the registry request fails', async () => {
+    globalThis.fetch = jest.fn().mockResolvedValue({
+      ok: false
+    }) as typeof fetch;
+
+    await expect(getOpenCommitLatestVersion()).resolves.toBeUndefined();
+  });
+
+  it('returns undefined when the registry request throws', async () => {
+    globalThis.fetch = jest
+      .fn()
+      .mockRejectedValue(new Error('network error')) as typeof fetch;
+
+    await expect(getOpenCommitLatestVersion()).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
Avoids the startup error when the default npm registry is private (e.g. CodeArtifact) by querying registry.npmjs.org directly instead of shelling out to `npm view`. Failures are now silent.

Closes #571