### PR TITLE
fix(deepseek): disable thinking mode to fix EMPTY_MESSAGE

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -135,7 +135,7 @@ export const MODEL_LIST = {
     'mistral-moderation-2411',
     'mistral-moderation-latest'
   ],
-  deepseek: ['deepseek-chat', 'deepseek-reasoner'],
+  deepseek: ['deepseek-v4-flash', 'deepseek-v4-pro'],
 
   // AI/ML API available chat-completion models
   // https://api.aimlapi.com/v1/models
@@ -896,7 +896,7 @@ export const RECOMMENDED_MODELS: Record<string, string> = {
   [OCO_AI_PROVIDER_ENUM.GEMINI]: 'gemini-1.5-flash',
   [OCO_AI_PROVIDER_ENUM.GROQ]: 'llama3-70b-8192',
   [OCO_AI_PROVIDER_ENUM.MISTRAL]: 'mistral-small-latest',
-  [OCO_AI_PROVIDER_ENUM.DEEPSEEK]: 'deepseek-chat',
+  [OCO_AI_PROVIDER_ENUM.DEEPSEEK]: 'deepseek-v4-flash',
   [OCO_AI_PROVIDER_ENUM.OPENROUTER]: 'openai/gpt-4o-mini',
   [OCO_AI_PROVIDER_ENUM.AIMLAPI]: 'gpt-4o-mini'
 };

--- a/src/engine/deepseek.ts
+++ b/src/engine/deepseek.ts
@@ -7,6 +7,16 @@ import { OpenAiEngine, OpenAiConfig } from './openAi';
 
 export interface DeepseekConfig extends OpenAiConfig {}
 
+// DeepSeek supports an undocumented `thinking` field in the chat completion
+// request body (not part of the OpenAI type definitions). The JavaScript SDK
+// forwards unknown top-level fields as-is, so `thinking` must sit at the top
+// level of the request — wrapping it in `extra_body` (a Python SDK helper)
+// would send an `extra_body` field instead and leave thinking mode enabled.
+interface DeepseekChatCompletionParams
+  extends OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming {
+  thinking?: { type: 'enabled' | 'disabled' };
+}
+
 export class DeepseekEngine extends OpenAiEngine {
   constructor(config: DeepseekConfig) {
     // Call OpenAIEngine constructor with forced Deepseek baseURL
@@ -21,7 +31,7 @@ export class DeepseekEngine extends OpenAiEngine {
   public generateCommitMessage = async (
     messages: Array<OpenAI.Chat.Completions.ChatCompletionMessageParam>
   ): Promise<string | null> => {
-    const params = {
+    const params: DeepseekChatCompletionParams = {
       model: this.config.model,
       messages,
       temperature: 0,
@@ -30,9 +40,8 @@ export class DeepseekEngine extends OpenAiEngine {
       // DeepSeek V4: disable thinking mode (enabled by default with effort=high).
       // Thinking mode returns reasoning in `reasoning_content` and can leave
       // `content` empty when max_tokens is low, causing EMPTY_MESSAGE errors.
-      // Per DeepSeek docs, `thinking` must be passed via `extra_body` in the
-      // OpenAI SDK. Commit message generation doesn't need chain-of-thought.
-      extra_body: { thinking: { type: 'disabled' } }
+      // Commit message generation doesn't need chain-of-thought.
+      thinking: { type: 'disabled' }
     };
 
     try {

--- a/src/engine/deepseek.ts
+++ b/src/engine/deepseek.ts
@@ -26,7 +26,13 @@ export class DeepseekEngine extends OpenAiEngine {
       messages,
       temperature: 0,
       top_p: 0.1,
-      max_tokens: this.config.maxTokensOutput
+      max_tokens: this.config.maxTokensOutput,
+      // DeepSeek V4: disable thinking mode (enabled by default with effort=high).
+      // Thinking mode returns reasoning in `reasoning_content` and can leave
+      // `content` empty when max_tokens is low, causing EMPTY_MESSAGE errors.
+      // Per DeepSeek docs, `thinking` must be passed via `extra_body` in the
+      // OpenAI SDK. Commit message generation doesn't need chain-of-thought.
+      extra_body: { thinking: { type: 'disabled' } }
     };
 
     try {

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -202,7 +202,7 @@ export function getRecommendedModel(provider: string): string | null {
     case OCO_AI_PROVIDER_ENUM.MISTRAL:
       return 'mistral-small-latest';
     case OCO_AI_PROVIDER_ENUM.DEEPSEEK:
-      return 'deepseek-chat';
+      return 'deepseek-v4-flash';
     case OCO_AI_PROVIDER_ENUM.OPENROUTER:
       return 'openai/gpt-4o-mini';
     case OCO_AI_PROVIDER_ENUM.AIMLAPI:

--- a/test/unit/deepseek.test.ts
+++ b/test/unit/deepseek.test.ts
@@ -1,0 +1,76 @@
+import { OpenAI } from 'openai';
+import { DeepseekEngine } from '../../src/engine/deepseek';
+
+describe('DeepseekEngine', () => {
+  const baseConfig = {
+    apiKey: 'test-deepseek-key',
+    maxTokensInput: 4096,
+    maxTokensOutput: 256
+  };
+
+  const messages: Array<OpenAI.Chat.Completions.ChatCompletionMessageParam> = [
+    { role: 'system', content: 'system message' },
+    { role: 'user', content: 'diff --git a/file b/file' }
+  ];
+
+  it('disables thinking mode via a top-level request body field', async () => {
+    const engine = new DeepseekEngine({
+      ...baseConfig,
+      model: 'deepseek-v4-flash'
+    });
+
+    const create = jest
+      .spyOn(engine.client.chat.completions, 'create')
+      .mockResolvedValue({
+        choices: [{ message: { content: 'feat(deepseek): thinking off' } }]
+      } as any);
+
+    await engine.generateCommitMessage(messages);
+
+    // The JavaScript OpenAI SDK forwards unknown top-level fields as-is, so
+    // `thinking` must be a top-level key in the request body for DeepSeek to
+    // honour it. See https://api-docs.deepseek.com/guides/thinking_mode
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'deepseek-v4-flash',
+        max_tokens: 256,
+        temperature: 0,
+        top_p: 0.1,
+        thinking: { type: 'disabled' }
+      })
+    );
+  });
+
+  it('does not send extra_body (a Python SDK helper) in the request', async () => {
+    const engine = new DeepseekEngine({
+      ...baseConfig,
+      model: 'deepseek-v4-flash'
+    });
+
+    const create = jest
+      .spyOn(engine.client.chat.completions, 'create')
+      .mockResolvedValue({
+        choices: [{ message: { content: 'feat(deepseek): no extra_body' } }]
+      } as any);
+
+    await engine.generateCommitMessage(messages);
+
+    // `extra_body` is only understood by the Python SDK. If it ever sneaks
+    // back into the JS request, DeepSeek receives an `extra_body` field and
+    // thinking mode stays enabled, re-introducing EMPTY_MESSAGE failures.
+    expect(create).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        extra_body: expect.anything()
+      })
+    );
+  });
+
+  it('uses the DeepSeek endpoint by default', () => {
+    const engine = new DeepseekEngine({
+      ...baseConfig,
+      model: 'deepseek-v4-flash'
+    });
+
+    expect(engine.client.baseURL).toContain('api.deepseek.com');
+  });
+});


### PR DESCRIPTION
### Problem
DeepSeek V4 enables thinking mode by default (effort=high). Chain-of-thought is returned in `reasoning_content`, leaving `content` empty when `max_tokens` is low. This caused `EMPTY_MESSAGE` errors during commit generation (reported with default 500 token output limit).

### Changes
- **`src/engine/deepseek.ts`**: Disable thinking mode via `extra_body: { thinking: { type: 'disabled' } }` (required for OpenAI SDK per [DeepSeek docs](https://api-docs.deepseek.com/zh-cn/guides/thinking_mode)). Commit messages don't need chain-of-thought; this also restores `temperature`/`top_p` behavior (ignored in thinking mode).
- **`src/commands/config.ts`**: Update `MODEL_LIST.deepseek` and `RECOMMENDED_MODELS` to current V4 models (`deepseek-v4-flash` / `deepseek-v4-pro`).
- **`src/utils/errors.ts`**: Update recommended model in error recovery.

### Verification
Tested locally: with thinking mode disabled, commit generation succeeds with default 500 token limit (previously required `OCO_TOKENS_MAX_OUTPUT=3000` workaround).