### PR TITLE
fix(hook): support git-managed paths and local providers

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -9,6 +9,9 @@ import { join as pathJoin, resolve as pathResolve } from 'path';
 import { COMMANDS } from './ENUMS';
 import { TEST_MOCK_TYPES } from '../engine/testAi';
 import { getI18nLocal, i18n } from '../i18n';
+import { OCO_AI_PROVIDER_ENUM } from '../utils/provider';
+
+export { OCO_AI_PROVIDER_ENUM } from '../utils/provider';
 
 export enum CONFIG_KEYS {
   OCO_API_KEY = 'OCO_API_KEY',
@@ -854,23 +857,6 @@ export const configValidators = {
     );
   }
 };
-
-export enum OCO_AI_PROVIDER_ENUM {
-  OLLAMA = 'ollama',
-  LLAMACPP = 'llamacpp',
-  OPENAI = 'openai',
-  ANTHROPIC = 'anthropic',
-  GEMINI = 'gemini',
-  AZURE = 'azure',
-  TEST = 'test',
-  FLOWISE = 'flowise',
-  GROQ = 'groq',
-  MISTRAL = 'mistral',
-  MLX = 'mlx',
-  DEEPSEEK = 'deepseek',
-  AIMLAPI = 'aimlapi',
-  OPENROUTER = 'openrouter'
-}
 
 export const PROVIDER_API_KEY_URLS: Record<string, string | null> = {
   [OCO_AI_PROVIDER_ENUM.OPENAI]: 'https://platform.openai.com/api-keys',

--- a/src/commands/githook.ts
+++ b/src/commands/githook.ts
@@ -4,30 +4,36 @@ import { command } from 'cleye';
 import { existsSync } from 'fs';
 import fs from 'fs/promises';
 import path from 'path';
-import { assertGitRepo, getCoreHooksPath } from '../utils/git.js';
+import { assertGitRepo, getGitHooksPath } from '../utils/git.js';
 import { COMMANDS } from './ENUMS';
 
 const HOOK_NAME = 'prepare-commit-msg';
-const DEFAULT_SYMLINK_URL = path.join('.git', 'hooks', HOOK_NAME);
 
 const getHooksPath = async (): Promise<string> => {
-  try {
-    const hooksPath = await getCoreHooksPath();
-    return path.join(hooksPath, HOOK_NAME);
-  } catch (error) {
-    return DEFAULT_SYMLINK_URL;
-  }
+  return path.join(await getGitHooksPath(), HOOK_NAME);
+};
+
+const normalizeHookPath = async (hookPath: string): Promise<string> => {
+  const absolutePath = path.resolve(hookPath);
+  const realDirectory = await fs.realpath(path.dirname(absolutePath));
+  return path.join(realDirectory, path.basename(absolutePath));
 };
 
 export const isHookCalled = async (): Promise<boolean> => {
-  const hooksPath = await getHooksPath();
-  return process.argv[1].endsWith(hooksPath);
+  try {
+    const invokedPath = process.argv[1];
+    if (!invokedPath) return false;
+
+    return (
+      (await normalizeHookPath(invokedPath)) ===
+      (await normalizeHookPath(await getHooksPath()))
+    );
+  } catch {
+    return false;
+  }
 };
 
-const isHookExists = async (): Promise<boolean> => {
-  const hooksPath = await getHooksPath();
-  return existsSync(hooksPath);
-};
+const isHookExists = (hooksPath: string): boolean => existsSync(hooksPath);
 
 export const hookCommand = command(
   {
@@ -36,16 +42,16 @@ export const hookCommand = command(
   },
   async (argv) => {
     const HOOK_URL = __filename;
-    const SYMLINK_URL = await getHooksPath();
     try {
       await assertGitRepo();
+      const SYMLINK_URL = await getHooksPath();
 
       const { setUnset: mode } = argv._;
 
       if (mode === 'set') {
         intro(`setting opencommit as '${HOOK_NAME}' hook at ${SYMLINK_URL}`);
 
-        if (await isHookExists()) {
+        if (isHookExists(SYMLINK_URL)) {
           let realPath;
           try {
             realPath = await fs.realpath(SYMLINK_URL);
@@ -74,7 +80,7 @@ export const hookCommand = command(
           `unsetting opencommit as '${HOOK_NAME}' hook from ${SYMLINK_URL}`
         );
 
-        if (!(await isHookExists())) {
+        if (!isHookExists(SYMLINK_URL)) {
           return outro(
             `OpenCommit wasn't previously set as '${HOOK_NAME}' hook, nothing to remove`
           );

--- a/src/commands/prepare-commit-msg-hook.ts
+++ b/src/commands/prepare-commit-msg-hook.ts
@@ -5,6 +5,7 @@ import { intro, outro, spinner } from '@clack/prompts';
 
 import { generateCommitMessageByDiff } from '../generateCommitMessageFromGitDiff';
 import { getChangedFiles, getDiff, getStagedFiles, gitAdd } from '../utils/git';
+import { getProviderConfigRequirement } from '../utils/provider';
 import { getConfig } from './config';
 
 const [messageFilePath, commitSource] = process.argv.slice(2);
@@ -39,7 +40,10 @@ export const prepareCommitMessageHook = async (
 
     const config = getConfig();
 
-    if (!config.OCO_API_KEY) {
+    if (
+      getProviderConfigRequirement(config.OCO_AI_PROVIDER) === 'apiKey' &&
+      !config.OCO_API_KEY
+    ) {
       outro(
         'No OCO_API_KEY is set. Set your key via `oco config set OCO_API_KEY=<value>. For more info see https://github.com/di-sukharev/opencommit'
       );

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -19,101 +19,86 @@ import {
   fetchOllamaModels,
   getCacheInfo
 } from '../utils/modelCache';
+import { getProviderConfigRequirement } from '../utils/provider';
 
 type ProviderSelectionGroup = 'primary' | 'other' | 'hidden';
-type FirstRunRequirement = 'apiKey' | 'model' | 'none';
 
 interface SetupProviderDefinition {
   provider: OCO_AI_PROVIDER_ENUM;
   displayName: string;
   selectionGroup: ProviderSelectionGroup;
-  firstRunRequirement: FirstRunRequirement;
 }
 
 const SETUP_PROVIDERS: SetupProviderDefinition[] = [
   {
     provider: OCO_AI_PROVIDER_ENUM.OPENAI,
     displayName: 'OpenAI (GPT)',
-    selectionGroup: 'primary',
-    firstRunRequirement: 'apiKey'
+    selectionGroup: 'primary'
   },
   {
     provider: OCO_AI_PROVIDER_ENUM.ANTHROPIC,
     displayName: 'Anthropic (Claude Sonnet, Opus)',
-    selectionGroup: 'primary',
-    firstRunRequirement: 'apiKey'
+    selectionGroup: 'primary'
   },
   {
     provider: OCO_AI_PROVIDER_ENUM.OLLAMA,
     displayName: 'Ollama (Free, runs locally)',
-    selectionGroup: 'primary',
-    firstRunRequirement: 'model'
+    selectionGroup: 'primary'
   },
   {
     provider: OCO_AI_PROVIDER_ENUM.LLAMACPP,
     displayName: 'llama.cpp (Free, runs locally)',
-    selectionGroup: 'primary',
-    firstRunRequirement: 'model'
+    selectionGroup: 'primary'
   },
   {
     provider: OCO_AI_PROVIDER_ENUM.GEMINI,
     displayName: 'Google Gemini',
-    selectionGroup: 'other',
-    firstRunRequirement: 'apiKey'
+    selectionGroup: 'other'
   },
   {
     provider: OCO_AI_PROVIDER_ENUM.GROQ,
     displayName: 'Groq (Fast inference, free tier)',
-    selectionGroup: 'other',
-    firstRunRequirement: 'apiKey'
+    selectionGroup: 'other'
   },
   {
     provider: OCO_AI_PROVIDER_ENUM.MISTRAL,
     displayName: 'Mistral AI',
-    selectionGroup: 'other',
-    firstRunRequirement: 'apiKey'
+    selectionGroup: 'other'
   },
   {
     provider: OCO_AI_PROVIDER_ENUM.DEEPSEEK,
     displayName: 'DeepSeek',
-    selectionGroup: 'other',
-    firstRunRequirement: 'apiKey'
+    selectionGroup: 'other'
   },
   {
     provider: OCO_AI_PROVIDER_ENUM.OPENROUTER,
     displayName: 'OpenRouter (Multiple providers)',
-    selectionGroup: 'other',
-    firstRunRequirement: 'apiKey'
+    selectionGroup: 'other'
   },
   {
     provider: OCO_AI_PROVIDER_ENUM.AIMLAPI,
     displayName: 'AI/ML API',
-    selectionGroup: 'other',
-    firstRunRequirement: 'apiKey'
+    selectionGroup: 'other'
   },
   {
     provider: OCO_AI_PROVIDER_ENUM.AZURE,
     displayName: 'Azure OpenAI',
-    selectionGroup: 'other',
-    firstRunRequirement: 'apiKey'
+    selectionGroup: 'other'
   },
   {
     provider: OCO_AI_PROVIDER_ENUM.MLX,
     displayName: 'MLX (Apple Silicon, local)',
-    selectionGroup: 'other',
-    firstRunRequirement: 'model'
+    selectionGroup: 'other'
   },
   {
     provider: OCO_AI_PROVIDER_ENUM.FLOWISE,
     displayName: OCO_AI_PROVIDER_ENUM.FLOWISE,
-    selectionGroup: 'hidden',
-    firstRunRequirement: 'apiKey'
+    selectionGroup: 'hidden'
   },
   {
     provider: OCO_AI_PROVIDER_ENUM.TEST,
     displayName: OCO_AI_PROVIDER_ENUM.TEST,
-    selectionGroup: 'hidden',
-    firstRunRequirement: 'none'
+    selectionGroup: 'hidden'
   }
 ];
 
@@ -136,10 +121,6 @@ function getProviderOptions(
 
 function getProviderDisplayName(provider: string): string {
   return getProviderDefinition(provider)?.displayName || provider;
-}
-
-function getFirstRunRequirement(provider: string): FirstRunRequirement {
-  return getProviderDefinition(provider)?.firstRunRequirement || 'apiKey';
 }
 
 async function selectProvider(): Promise<string | symbol> {
@@ -239,7 +220,7 @@ async function selectModel(
 
   if (models.length === 0) {
     // Providers without API keys can accept a local model name directly.
-    if (getFirstRunRequirement(provider) !== 'apiKey') {
+    if (getProviderConfigRequirement(provider) !== 'apiKey') {
       return await text({
         message: 'Enter model name (e.g., llama3:8b, mistral):',
         placeholder: 'llama3:8b',
@@ -548,7 +529,7 @@ export function isFirstRun(): boolean {
 
   const provider = config.OCO_AI_PROVIDER || OCO_AI_PROVIDER_ENUM.OPENAI;
 
-  const requirement = getFirstRunRequirement(provider);
+  const requirement = getProviderConfigRequirement(provider);
   const hasRequiredConfig =
     requirement === 'model'
       ? Boolean(config.OCO_MODEL)
@@ -564,7 +545,7 @@ export async function promptForMissingApiKey(): Promise<boolean> {
   const config = getConfig();
   const provider = config.OCO_AI_PROVIDER || OCO_AI_PROVIDER_ENUM.OPENAI;
 
-  if (getFirstRunRequirement(provider) !== 'apiKey') {
+  if (getProviderConfigRequirement(provider) !== 'apiKey') {
     return true; // No API key needed
   }
 

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -1,7 +1,7 @@
 import { execa } from 'execa';
 import { readFileSync, existsSync } from 'fs';
 import ignore, { Ignore } from 'ignore';
-import { join } from 'path';
+import { join, resolve as pathResolve } from 'path';
 import { homedir } from 'os';
 import { outro, spinner } from '@clack/prompts';
 
@@ -44,14 +44,14 @@ export const getOpenCommitIgnore = async (): Promise<Ignore> => {
   return ig;
 };
 
-export const getCoreHooksPath = async (): Promise<string> => {
+export const getGitHooksPath = async (): Promise<string> => {
   const gitDir = await getGitDir();
 
-  const { stdout } = await execa('git', ['config', 'core.hooksPath'], {
+  const { stdout } = await execa('git', ['rev-parse', '--git-path', 'hooks'], {
     cwd: gitDir
   });
 
-  return stdout;
+  return pathResolve(gitDir, stdout);
 };
 
 export const getStagedFiles = async (): Promise<string[]> => {

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -1,0 +1,43 @@
+export enum OCO_AI_PROVIDER_ENUM {
+  OLLAMA = 'ollama',
+  LLAMACPP = 'llamacpp',
+  OPENAI = 'openai',
+  ANTHROPIC = 'anthropic',
+  GEMINI = 'gemini',
+  AZURE = 'azure',
+  TEST = 'test',
+  FLOWISE = 'flowise',
+  GROQ = 'groq',
+  MISTRAL = 'mistral',
+  MLX = 'mlx',
+  DEEPSEEK = 'deepseek',
+  AIMLAPI = 'aimlapi',
+  OPENROUTER = 'openrouter'
+}
+
+export type ProviderConfigRequirement = 'apiKey' | 'model' | 'none';
+
+const PROVIDER_CONFIG_REQUIREMENTS: Record<
+  OCO_AI_PROVIDER_ENUM,
+  ProviderConfigRequirement
+> = {
+  [OCO_AI_PROVIDER_ENUM.OPENAI]: 'apiKey',
+  [OCO_AI_PROVIDER_ENUM.ANTHROPIC]: 'apiKey',
+  [OCO_AI_PROVIDER_ENUM.OLLAMA]: 'model',
+  [OCO_AI_PROVIDER_ENUM.LLAMACPP]: 'model',
+  [OCO_AI_PROVIDER_ENUM.GEMINI]: 'apiKey',
+  [OCO_AI_PROVIDER_ENUM.GROQ]: 'apiKey',
+  [OCO_AI_PROVIDER_ENUM.MISTRAL]: 'apiKey',
+  [OCO_AI_PROVIDER_ENUM.DEEPSEEK]: 'apiKey',
+  [OCO_AI_PROVIDER_ENUM.OPENROUTER]: 'apiKey',
+  [OCO_AI_PROVIDER_ENUM.AIMLAPI]: 'apiKey',
+  [OCO_AI_PROVIDER_ENUM.AZURE]: 'apiKey',
+  [OCO_AI_PROVIDER_ENUM.MLX]: 'model',
+  [OCO_AI_PROVIDER_ENUM.FLOWISE]: 'apiKey',
+  [OCO_AI_PROVIDER_ENUM.TEST]: 'none'
+};
+
+export const getProviderConfigRequirement = (
+  provider: string = OCO_AI_PROVIDER_ENUM.OPENAI
+): ProviderConfigRequirement =>
+  PROVIDER_CONFIG_REQUIREMENTS[provider as OCO_AI_PROVIDER_ENUM] || 'apiKey';

--- a/test/e2e/cliBehavior.test.ts
+++ b/test/e2e/cliBehavior.test.ts
@@ -15,6 +15,7 @@ import {
   getMockOpenAiEnv,
   prepareEnvironment,
   prepareRepo,
+  prepareSubmoduleEnvironment,
   prepareTempDir,
   runCli,
   runGit,
@@ -479,29 +480,94 @@ it('cli applies the documented message template placeholder from extra args', as
   }
 });
 
-it('hook command sets and unsets the prepare-commit-msg symlink', async () => {
+const expectHookSetAndUnset = async ({
+  cwd,
+  hookPath
+}: {
+  cwd: string;
+  hookPath: string;
+}): Promise<void> => {
+  const cliPath = realpathSync(resolve('./out/cli.cjs'));
+
+  const setHook = await runCli(['hook', 'set'], { cwd });
+
+  expect(await setHook.findByText('Hook set')).toBeInTheConsole();
+  expect(await waitForExit(setHook)).toBe(0);
+  expect(lstatSync(hookPath).isSymbolicLink()).toBe(true);
+  expect(realpathSync(hookPath)).toBe(cliPath);
+
+  const unsetHook = await runCli(['hook', 'unset'], { cwd });
+
+  expect(await unsetHook.findByText('Hook is removed')).toBeInTheConsole();
+  expect(await waitForExit(unsetHook)).toBe(0);
+  expect(existsSync(hookPath)).toBe(false);
+};
+
+it('hook command respects a relative core.hooksPath from a nested directory', async () => {
   const { gitDir, cleanup } = await prepareEnvironment();
-  const hookPath = resolve(gitDir, '.git/hooks/prepare-commit-msg');
-  const cliPath = resolve('./out/cli.cjs');
+  const nestedDir = resolve(gitDir, 'packages/app');
+  const hookPath = resolve(gitDir, 'custom-hooks/prepare-commit-msg');
 
   try {
-    const setHook = await runCli(['hook', 'set'], {
-      cwd: gitDir
+    writeRepoFile(gitDir, 'packages/app/.gitkeep', '');
+    await runGit(['config', 'core.hooksPath', 'custom-hooks'], gitDir);
+
+    await expectHookSetAndUnset({
+      cwd: nestedDir,
+      hookPath
     });
+  } finally {
+    await cleanup();
+  }
+});
 
-    expect(await setHook.findByText('Hook set')).toBeInTheConsole();
-    expect(await waitForExit(setHook)).toBe(0);
-    expect(existsSync(hookPath)).toBe(true);
-    expect(lstatSync(hookPath).isSymbolicLink()).toBe(true);
-    expect(realpathSync(hookPath)).toBe(cliPath);
+it('hook command sets and unsets the prepare-commit-msg symlink in a submodule', async () => {
+  const { submoduleDir, cleanup } = await prepareSubmoduleEnvironment();
+  const { stdout: absoluteGitDir } = await runGit(
+    ['rev-parse', '--absolute-git-dir'],
+    submoduleDir
+  );
+  const hookPath = resolve(absoluteGitDir.trim(), 'hooks/prepare-commit-msg');
 
-    const unsetHook = await runCli(['hook', 'unset'], {
-      cwd: gitDir
+  try {
+    await expectHookSetAndUnset({
+      cwd: submoduleDir,
+      hookPath
     });
+  } finally {
+    await cleanup();
+  }
+});
 
-    expect(await unsetHook.findByText('Hook is removed')).toBeInTheConsole();
-    expect(await waitForExit(unsetHook)).toBe(0);
-    expect(existsSync(hookPath)).toBe(false);
+it('hook command uses the shared hooks directory from a linked worktree', async () => {
+  const { tempDir, gitDir, cleanup } = await prepareEnvironment();
+  const worktreeDir = resolve(tempDir, 'worktree');
+
+  try {
+    await prepareRepo(
+      gitDir,
+      { 'README.md': '# fixture\n' },
+      { commitMessage: 'test: initialize repository' }
+    );
+    await runGit(
+      ['worktree', 'add', '-b', 'hook-worktree', worktreeDir],
+      gitDir
+    );
+
+    const { stdout: commonGitDir } = await runGit(
+      ['rev-parse', '--git-common-dir'],
+      worktreeDir
+    );
+    const hookPath = resolve(
+      worktreeDir,
+      commonGitDir.trim(),
+      'hooks/prepare-commit-msg'
+    );
+
+    await expectHookSetAndUnset({
+      cwd: worktreeDir,
+      hookPath
+    });
   } finally {
     await cleanup();
   }
@@ -549,6 +615,95 @@ it('prepare-commit-msg hook writes the generated message into the commit message
   } finally {
     await server.cleanup();
     await cleanup();
+  }
+});
+
+it('prepare-commit-msg hook supports llama.cpp without an API key', async () => {
+  const { gitDir, cleanup } = await prepareEnvironment();
+  const homeDir = await prepareTempDir();
+  const server = await startMockOpenAiServer(
+    'fix(hook): support local providers without keys'
+  );
+  const hookPath = resolve(gitDir, '.git/hooks/prepare-commit-msg');
+  const messageFile = resolve(gitDir, '.git/COMMIT_EDITMSG');
+
+  try {
+    await prepareRepo(
+      gitDir,
+      {
+        'index.ts': 'console.log("Hello World");\n'
+      },
+      { stage: true }
+    );
+
+    const setHook = await runCli(['hook', 'set'], { cwd: gitDir });
+    expect(await waitForExit(setHook)).toBe(0);
+
+    writeFileSync(messageFile, '# existing\n');
+
+    const hookRun = await runProcess(hookPath, [messageFile], {
+      cwd: gitDir,
+      env: {
+        HOME: homeDir,
+        OCO_AI_PROVIDER: 'llamacpp',
+        OCO_API_KEY: '',
+        OCO_API_URL: new URL(server.baseUrl).origin,
+        OCO_MODEL: 'local-test-model',
+        OCO_GITPUSH: 'false'
+      }
+    });
+
+    expect(await hookRun.findByText('Done')).toBeInTheConsole();
+    expect(await waitForExit(hookRun)).toBe(0);
+    expect(readFileSync(messageFile, 'utf8')).toContain(
+      '# fix(hook): support local providers without keys'
+    );
+    expect(server.requestBodies).toHaveLength(1);
+    expect(server.authHeaders).toHaveLength(0);
+  } finally {
+    await server.cleanup();
+    await cleanup();
+    rmSync(homeDir, { force: true, recursive: true });
+  }
+});
+
+it('prepare-commit-msg hook preserves the message when OpenAI has no API key', async () => {
+  const { gitDir, cleanup } = await prepareEnvironment();
+  const homeDir = await prepareTempDir();
+  const hookPath = resolve(gitDir, '.git/hooks/prepare-commit-msg');
+  const messageFile = resolve(gitDir, '.git/COMMIT_EDITMSG');
+  const originalMessage = '# existing\n';
+
+  try {
+    await prepareRepo(
+      gitDir,
+      {
+        'index.ts': 'console.log("Hello World");\n'
+      },
+      { stage: true }
+    );
+
+    const setHook = await runCli(['hook', 'set'], { cwd: gitDir });
+    expect(await waitForExit(setHook)).toBe(0);
+
+    writeFileSync(messageFile, originalMessage);
+
+    const hookRun = await runProcess(hookPath, [messageFile], {
+      cwd: gitDir,
+      env: getMockOpenAiEnv('http://127.0.0.1:1/v1', {
+        HOME: homeDir,
+        OCO_API_KEY: ''
+      })
+    });
+
+    expect(
+      await hookRun.findByText('No OCO_API_KEY is set')
+    ).toBeInTheConsole();
+    expect(await waitForExit(hookRun)).toBe(0);
+    expect(readFileSync(messageFile, 'utf8')).toBe(originalMessage);
+  } finally {
+    await cleanup();
+    rmSync(homeDir, { force: true, recursive: true });
   }
 });
 

--- a/test/e2e/utils.ts
+++ b/test/e2e/utils.ts
@@ -21,7 +21,12 @@ const fsRemove = promisify(rm);
 
 const CLI_PATH = path.resolve(process.cwd(), 'out/cli.cjs');
 const DEFAULT_TEST_ENV = {
-  OCO_TEST_SKIP_VERSION_CHECK: 'true'
+  OCO_TEST_SKIP_VERSION_CHECK: 'true',
+  GIT_CONFIG_NOSYSTEM: '1',
+  GIT_CONFIG_GLOBAL: path.resolve(
+    tmpdir(),
+    `opencommit-test-empty-global-gitconfig-${process.pid}`
+  )
 };
 const COMPLETED_MIGRATIONS = [
   '00_use_single_api_key_and_url',
@@ -66,9 +71,17 @@ export const runCli = async (
 
 export const runGit = async (
   args: string[],
-  cwd: string
+  cwd: string,
+  env: NodeJS.ProcessEnv = {}
 ): Promise<{ stdout: string; stderr: string }> => {
-  const { stdout = '', stderr = '' } = await fsExecFile('git', args, { cwd });
+  const { stdout = '', stderr = '' } = await fsExecFile('git', args, {
+    cwd,
+    env: {
+      ...process.env,
+      ...DEFAULT_TEST_ENV,
+      ...env
+    }
+  });
   return { stdout, stderr };
 };
 
@@ -92,21 +105,17 @@ export const prepareEnvironment = async ({
   let otherRemoteDir: string | undefined;
 
   if (remotes === 0) {
-    await fsExecFile('git', ['init', 'test'], { cwd: tempDir });
+    await runGit(['init', 'test'], tempDir);
   } else {
-    await fsExecFile('git', ['init', '--bare', 'remote.git'], {
-      cwd: tempDir
-    });
+    await runGit(['init', '--bare', 'remote.git'], tempDir);
     remoteDir = path.resolve(tempDir, 'remote.git');
 
     if (remotes === 2) {
-      await fsExecFile('git', ['init', '--bare', 'other.git'], {
-        cwd: tempDir
-      });
+      await runGit(['init', '--bare', 'other.git'], tempDir);
       otherRemoteDir = path.resolve(tempDir, 'other.git');
     }
 
-    await fsExecFile('git', ['clone', 'remote.git', 'test'], { cwd: tempDir });
+    await runGit(['clone', 'remote.git', 'test'], tempDir);
 
     if (remotes === 2) {
       await runGit(['remote', 'add', 'other', '../other.git'], gitDir);
@@ -128,6 +137,47 @@ export const prepareEnvironment = async ({
     otherRemoteDir,
     cleanup
   };
+};
+
+export const prepareSubmoduleEnvironment = async (): Promise<{
+  tempDir: string;
+  parentDir: string;
+  submoduleDir: string;
+  cleanup: () => Promise<void>;
+}> => {
+  const tempDir = await prepareTempDir();
+  const parentDir = path.resolve(tempDir, 'parent');
+  const sourceDir = path.resolve(tempDir, 'source');
+  const submoduleDir = path.resolve(parentDir, 'nested');
+
+  await runGit(['init', 'source'], tempDir);
+  await configureGitUser(sourceDir);
+  await runGit(
+    ['-c', 'core.hooksPath=/dev/null', 'commit', '--allow-empty', '-m', 'init'],
+    sourceDir
+  );
+
+  await runGit(['init', 'parent'], tempDir);
+  await configureGitUser(parentDir);
+  await runGit(
+    [
+      '-c',
+      'protocol.file.allow=always',
+      'submodule',
+      'add',
+      sourceDir,
+      'nested'
+    ],
+    parentDir
+  );
+
+  const cleanup = async () => {
+    if (existsSync(tempDir)) {
+      await fsRemove(tempDir, { force: true, recursive: true });
+    }
+  };
+
+  return { tempDir, parentDir, submoduleDir, cleanup };
 };
 
 export const prepareTempDir = async (): Promise<string> => {
@@ -308,7 +358,13 @@ export const getRemoteBranchHeadSubject = async (
       '--pretty=%s',
       `refs/heads/${branchName}`
     ],
-    { cwd: process.cwd() }
+    {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        ...DEFAULT_TEST_ENV
+      }
+    }
   );
 
   return stdout.trim();
@@ -329,7 +385,13 @@ export const remoteBranchExists = async (
         '--quiet',
         `refs/heads/${branchName}`
       ],
-      { cwd: process.cwd() }
+      {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          ...DEFAULT_TEST_ENV
+        }
+      }
     );
     return true;
   } catch {


### PR DESCRIPTION
## Summary

- resolve the effective hooks directory through Git so hook setup works with relative core.hooksPath values, submodules, and linked worktrees
- centralize provider configuration requirements and allow Ollama, MLX, and llama.cpp hooks to run without a fake API key
- add subprocess E2E coverage for hook path variants and credential behavior, with Git configuration isolated from the host environment
- rebuild the tracked CLI bundle so the fixes ship to npm consumers

## Test plan

- npm run lint
- npm run test:unit -- --runInBand
- OCO_TEST_SKIP_VERSION_CHECK=true npx jest test/e2e/cliBehavior.test.ts test/e2e/geminiBehavior.test.ts test/e2e/gitPush.test.ts test/e2e/oneFile.test.ts test/e2e/noChanges.test.ts --runInBand

Closes #224
Closes #438